### PR TITLE
Bridge interface should be used as normal

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -110,7 +110,7 @@ register() {
 	local raw=$(ifconfig $MAC_INTERFACE 2&> /dev/null)
 	# if previous command fails, fallback to first non-loopback interface
 	if [ -z "$raw" ]; then raw=$(ifconfig); fi
-	local macaddr=$(echo "$raw " | egrep -v "^(lo|br-|tap[0-9]+)" | awk '/HWaddr/ { print $5 }' | head -n 1)
+	local macaddr=$(echo "$raw " | egrep -v "^(lo|tap[0-9]+)" | awk '/HWaddr/ { print $5 }' | head -n 1)
 	# convert hostname to lowercase for case insensitive check
 	local name=$(echo $hostname | awk '{print tolower($0)}')
 	# use macaddress if hostname is the default one or empty


### PR DESCRIPTION
In many cases it is necessary to use bridge interface with ip interface for management (for example br-lan with included Tinc interface, adhoc0 and eth0). Though, it can be used as normal interface.
Also in some cases bridge interface can use its own mac address. So it is better to exclude only loopback and tap interfaces.