### PR TITLE
[agent] Send device information during registration #32

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -119,6 +119,10 @@ register() {
 	fi
 	local backend="netjsonconfig.OpenWrt"
 	local tags=$(uci get openwisp.http.tags 2&> /dev/null)
+	# get OS identifier & device model
+	source /etc/openwrt_release
+	local os=$DISTRIB_DESCRIPTION
+	local model=$(cat /tmp/sysinfo/model)
 	# prepare POST params
 	local params="backend=$backend"
 	# generate key from macaddress + shared secret
@@ -131,6 +135,8 @@ register() {
 	                 --data-urlencode name="$hostname" \
 	                 --data-urlencode mac_address="$macaddr" \
 	                 --data-urlencode tags="$tags" \
+	                 --data-urlencode model="$model" \
+	                 --data-urlencode os="$os" \
 	                 -i $REGISTRATION_URL > $REGISTRATION_PARAMETERS)
 	local exit_code=$?
 	# report eventual failures and return


### PR DESCRIPTION
I took advantage of this moment to refactor the curl registration call
which now should be more robust because the less predictable variables
are url-encoded before being sent via HTTP

Implements and closes #32