### PR TITLE
Added Luacheck and travis.yml with install-config 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# .travis.yml
+language: python
+sudo: true
+env:
+  - LUA="lua=5.1.5"
+before_install:
+  - sudo ./install-dev.sh
+
+install:
+  - sudo luarocks install luacheck
+
+script:
+  - ./runtests

--- a/openwisp-config/tests/test_utils.lua
+++ b/openwisp-config/tests/test_utils.lua
@@ -2,7 +2,7 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-require('uci')
+uci = require('uci')
 local utils = require('openwisp.utils')
 luaunit = require('luaunit')
 write_dir = './utils'

--- a/runtests
+++ b/runtests
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 cd openwisp-config/tests/
+luacheck . -d -a -r
 lua test_store_unmanaged.lua -v
 lua test_restore_unmanaged.lua -v
 lua test_uci_autoname.lua -v


### PR DESCRIPTION
### Files added/changed - _Summary_ 
- added travis.yml with **dependencies installation configuration.**
- added luacheck test command with parameters (_-d -a -r_) to filter unwanted warnings in **runtests script**

- after running runtests script
 -- fixed **`accessing undefined variable uci`** warning by making **`uci`** global variable and assigning to `require('uci')`in `openwisp-config/tests/test_utils.lua` file

fixes #77 

this is a submission for **GCI task**- **Add travis-ci configuration for luacheck - OpenWISP**