### PR TITLE
[tests] Install lua-check in install-dev.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - sudo ./install-dev.sh
 
 install:
-  - sudo luarocks install luacheck
   - pip install openwisp-utils[qa]>=0.2.1
 
 script:

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -21,9 +21,8 @@ ldconfig -v
 # install luafilesystem
 luarocks install luafilesystem
 # install luaunit
-git clone https://github.com/bluebird75/luaunit.git --depth=1
-mkdir -p /usr/share/lua/5.1/
-cd luaunit && cp luaunit.lua /usr/share/lua/5.1/ && cd ..
-test -f /usr/share/lua/5.1/luaunit.lua
+luarocks install luaunit
+# install luacheck
+luarocks install luacheck
 # clean
-rm -rf json-c libubox uci luaunit
+rm -rf json-c libubox uci


### PR DESCRIPTION
`luacheck` is now called in the `runtests` script but it won't be installed through the `install-dev.sh` script. This PR fixes that.

Related question: is there a reason why `luafilesystem` and `luaunit` are not installed with `apt`?