### PR TITLE
[ci] Fix .travis.yml errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # .travis.yml
 language: python
-sudo: true
 env:
   - LUA="lua=5.1.5"
 before_install:


### PR DESCRIPTION
The following errors arose when using https://config.travis-ci.com/explore:
[warn] on root: deprecated key: "sudo" (The key `sudo` has no effect anymore.)
~~[info] on root: missing os, using the default "linux"~~