### PR TITLE
[luacheck] Run luacheck on all files and fix warnings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,4 @@
+ignore = {"213/_.*"} -- unused Loop Variables beginning with underscore
+files["openwisp-config/tests"] = {
+    ignore = {"11./Test.*"} -- globals relating to defining unittests
+}

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -4,7 +4,7 @@ local net = {}
 
 function net.get_interface(name, family)
     local uci_cursor = uci.cursor()
-    local family = family or 'inet'
+    local ip_family = family or 'inet'
     -- if UCI network name is a bridge, the ifname won't be the name of the bridge
     local is_bridge = uci_cursor:get('network', name, 'type') == 'bridge'
     local ifname
@@ -17,8 +17,8 @@ function net.get_interface(name, family)
     end
     -- get list of interfaces and loop until found
     local interfaces = nixio.getifaddrs()
-    for i, interface in pairs(interfaces) do
-        if interface.name == ifname and interface.family == family then
+    for _, interface in pairs(interfaces) do
+        if interface.name == ifname and interface.family == ip_family then
             return interface
         end
     end

--- a/openwisp-config/files/lib/openwisp/utils.lua
+++ b/openwisp-config/files/lib/openwisp/utils.lua
@@ -30,18 +30,18 @@ end
 
 function utils.dirname(path)
     local parts = utils.split(path, '/')
-    local path = '/'
+    local returnPath = '/'
     local length = table.getn(parts)
     for i, part in ipairs(parts) do
         if i < length then
-            path = path..part..'/'
+            returnPath = returnPath..part..'/'
         end
     end
-    return path
+    return returnPath
 end
 
 function utils.add_values_to_set(set, values)
-    for i, el in pairs(values) do
+    for _, el in pairs(values) do
         set[el] = true
     end
     return set
@@ -142,10 +142,10 @@ end
 
 -- Code by David Kastrup
 -- http://lua-users.org/wiki/DirTreeIterator
-function utils.dirtree(dir)
-    assert(dir and dir ~= '', 'directory parameter is missing or empty')
-    if string.sub(dir, -1) == '/' then
-        local dir = string.sub(dir, 1, -2)
+function utils.dirtree(dirParam)
+    assert(dirParam and dirParam ~= '', 'directory parameter is missing or empty')
+    if string.sub(dirParam, -1) == '/' then
+        dirParam = string.sub(dirParam, 1, -2)
     end
     local function yieldtree(dir)
         for entry in lfs.dir(dir) do
@@ -159,7 +159,7 @@ function utils.dirtree(dir)
             end
         end
     end
-    return coroutine.wrap(function() yieldtree(dir) end)
+    return coroutine.wrap(function() yieldtree(dirParam) end)
 end
 
 function utils.file_exists(path)

--- a/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
+++ b/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
@@ -1,11 +1,12 @@
 #!/usr/bin/env lua
 -- removes OpenWrt/LEDE default wifi-iface settings, if present
 
-require('uci')
+local uci = require('uci')
 
 -- parse arguments
+local test
 local arg={...}
-for key, value in pairs(arg) do
+for _, value in pairs(arg) do
     -- test argument
     if value == '--test=1' then test = true; end
 end
@@ -16,7 +17,7 @@ local standard_path = standard_prefix .. 'config/'
 local standard = uci.cursor(standard_path)
 local changed = false
 
-function is_default_wifi(section)
+local function is_default_wifi(section)
     if section.encryption == 'none' and
        section.mode == 'ap'         and
        section.network == 'lan'     and

--- a/openwisp-config/files/sbin/openwisp-restore-unmanaged.lua
+++ b/openwisp-config/files/sbin/openwisp-restore-unmanaged.lua
@@ -1,10 +1,12 @@
 #!/usr/bin/env lua
 -- restores unmanaged configurations
 
-require('uci')
+local uci = require('uci')
+local lfs = require('lfs')
 local utils = require('openwisp.utils')
 
 -- parse arguments
+local test = false
 local arg={...}
 for key, value in pairs(arg) do
     -- test argument

--- a/openwisp-config/files/sbin/openwisp-store-unmanaged.lua
+++ b/openwisp-config/files/sbin/openwisp-store-unmanaged.lua
@@ -1,14 +1,15 @@
 #!/usr/bin/env lua
 -- stores unmanaged configurations
 
-require('os')
-require('io')
-require('uci')
+local os = require('os')
+local io = require('io')
+local uci = require('uci')
 local utils = require('openwisp.utils')
 local sections
 local arg={...}
 
 -- parse arguments
+local test = false
 for key, value in pairs(arg) do
     -- test argument
     if value == '--test=1' then test = true; end
@@ -25,7 +26,7 @@ local standard_path = standard_prefix .. 'config/'
 local unmanaged_path = unmanaged_prefix .. 'unmanaged/'
 local uci_tmp_path = '/tmp/openwisp/.uci'
 
-function empty_file(path)
+local function empty_file(path)
     local file = io.open(path, 'w')
     file:write('')
     file:close()
@@ -46,7 +47,7 @@ end
 -- }
 local unmanaged_map = {}
 local section_list = utils.split(sections)
-for i, section in pairs(section_list) do
+for _, section in pairs(section_list) do
     local parts = utils.split(section, '.')
     -- skip unrecognized strings
     if parts[1] and parts[2] then
@@ -64,7 +65,7 @@ for i, section in pairs(section_list) do
             if not unmanaged_map[config] then
                 unmanaged_map[config] = {}
             end
-            el = {name=section_name, type=section_type}
+            local el = {name=section_name, type=section_type}
             table.insert(unmanaged_map[config], el)
         end
     end

--- a/openwisp-config/files/sbin/openwisp-update-config.lua
+++ b/openwisp-config/files/sbin/openwisp-update-config.lua
@@ -1,50 +1,50 @@
 #!/usr/bin/env lua
 -- openwisp-config configuration updater
 
-require('os')
-require('lfs')
-require('uci')
+local os = require('os')
+local lfs = require('lfs')
+local uci = require('uci')
 local utils = require('openwisp.utils')
 local arg = {...}
 
 -- parse arguments
-MERGE = true
-TEST = false
-for key, value in pairs(arg) do
+local MERGE = true
+local TEST = false
+for _, value in pairs(arg) do
     -- test argument
     if value == '--merge=0' then MERGE = false; end
     if value == '--test=1' then TEST = true; end
 end
 
-working_dir = lfs.currentdir()
-tmp_dir = not TEST and '/tmp/openwisp' or working_dir
-check_dir = tmp_dir .. '/check'
-check_config_dir = check_dir..'/etc/config'
-downloaded_conf = tmp_dir .. '/configuration.tar.gz'
-openwisp_dir = not TEST and '/etc/openwisp' or working_dir .. '/openwisp'
-standard_config_dir = not TEST and '/etc/config' or working_dir .. '/update-test/etc/config'
-test_root_dir = working_dir .. '/update-test'
-remote_dir = openwisp_dir .. '/remote'
-remote_config_dir = remote_dir .. '/etc/config'
-stored_dir = openwisp_dir .. '/stored'
-added_file = openwisp_dir .. '/added.list'
-modified_file = openwisp_dir .. '/modified.list'
-get_standard = function() return uci.cursor(standard_config_dir) end
-get_remote = function() return uci.cursor(remote_config_dir, '/tmp/openwisp/.uci') end
-get_check = function() return uci.cursor(check_config_dir, '/tmp/openwisp/.uci') end
+local working_dir = lfs.currentdir()
+local tmp_dir = not TEST and '/tmp/openwisp' or working_dir
+local check_dir = tmp_dir .. '/check'
+local check_config_dir = check_dir..'/etc/config'
+local downloaded_conf = tmp_dir .. '/configuration.tar.gz'
+local openwisp_dir = not TEST and '/etc/openwisp' or working_dir .. '/openwisp'
+local standard_config_dir = not TEST and '/etc/config' or working_dir .. '/update-test/etc/config'
+local test_root_dir = working_dir .. '/update-test'
+local remote_dir = openwisp_dir .. '/remote'
+local remote_config_dir = remote_dir .. '/etc/config'
+local stored_dir = openwisp_dir .. '/stored'
+local added_file = openwisp_dir .. '/added.list'
+local modified_file = openwisp_dir .. '/modified.list'
+local get_standard = function() return uci.cursor(standard_config_dir) end
+local get_remote = function() return uci.cursor(remote_config_dir, '/tmp/openwisp/.uci') end
+local get_check = function() return uci.cursor(check_config_dir, '/tmp/openwisp/.uci') end
 
 -- uci cursors
-standard = get_standard()
-remote = get_remote()
+local standard = get_standard()
+local remote = get_remote()
 
 -- check downloaded UCI files before proceeding
 os.execute('mkdir -p '..check_dir)
 os.execute('tar -zxf '..downloaded_conf..' -C '..check_dir)
-check = get_check()
+local check = get_check()
 
 if lfs.attributes(check_config_dir, 'mode') == 'directory' then
     for file in lfs.dir(check_config_dir) do
-        path = check_config_dir..'/'..file
+        local path = check_config_dir..'/'..file
         if lfs.attributes(path, 'mode') == 'file' then
             if check:get_all(file) == nil then
                 print('ERROR: invalid UCI configuration file: '..file)
@@ -67,7 +67,7 @@ if lfs.attributes(remote_config_dir, 'mode') == 'directory' then
     for file in lfs.dir(remote_config_dir) do
         local standard_path = standard_config_dir .. '/' .. file
         if lfs.attributes(standard_path, 'mode') == 'file' then
-            for key, section in pairs(remote:get_all(file)) do
+            for _, section in pairs(remote:get_all(file)) do
                 -- search section in the downloaded configuration
                 local section_check = check:get(file, section['.name'])
                 -- remove section from current configuration if not in downloaded configuration
@@ -92,8 +92,8 @@ if lfs.attributes(remote_config_dir, 'mode') == 'directory' then
             end
             standard:commit(file)
             -- remove uci file if empty
-            local uci = standard:get_all(file)
-            if uci and utils.is_table_empty(uci) then
+            local uciFile = standard:get_all(file)
+            if uciFile and utils.is_table_empty(uciFile) then
                 os.remove(standard_path)
             end
         end
@@ -120,7 +120,7 @@ if lfs.attributes(remote_config_dir, 'mode') == 'directory' then
             if MERGE then
                 -- avoid "file does not exist" error
                 os.execute('touch ' .. standard_path)
-                for key, section in pairs(remote:get_all(file)) do
+                for _, section in pairs(remote:get_all(file)) do
                     utils.write_uci_section(standard, file, section)
                 end
                 standard:commit(file)
@@ -136,14 +136,14 @@ end
 os.execute('touch ' .. added_file)
 os.execute('touch ' .. modified_file)
 -- convert lists to lua sets
-added = utils.file_to_set(added_file)
-modified = utils.file_to_set(modified_file)
-added_changed = false
-modified_changed = false
+local added = utils.file_to_set(added_file)
+local modified = utils.file_to_set(modified_file)
+local added_changed = false
+local modified_changed = false
 
 -- loop each file except directories and standard UCI config files
-ignored_path = remote_config_dir .. '/'
-function is_ignored(path)
+local ignored_path = remote_config_dir .. '/'
+local function is_ignored(path)
     return utils.starts_with(path, ignored_path)
 end
 

--- a/openwisp-config/tests/test_remove_default_wifi.lua
+++ b/openwisp-config/tests/test_remove_default_wifi.lua
@@ -1,7 +1,7 @@
 require('os')
 require('io')
-luaunit = require('luaunit')
-remove_default_wifi = assert(loadfile("../files/sbin/openwisp-remove-default-wifi.lua"))
+local luaunit = require('luaunit')
+local remove_default_wifi = assert(loadfile("../files/sbin/openwisp-remove-default-wifi.lua"))
 
 TestRemoveDefaultWifi = {
     setUp = function()

--- a/openwisp-config/tests/test_restore_unmanaged.lua
+++ b/openwisp-config/tests/test_restore_unmanaged.lua
@@ -2,9 +2,9 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-luaunit = require('luaunit')
-restore_unmanaged = assert(loadfile("../files/sbin/openwisp-restore-unmanaged.lua"))
-write_dir = './unmanaged/'
+local luaunit = require('luaunit')
+local restore_unmanaged = assert(loadfile("../files/sbin/openwisp-restore-unmanaged.lua"))
+local write_dir = './unmanaged/'
 
 TestRestoreUnmanaged = {
     setUp = function()

--- a/openwisp-config/tests/test_store_unmanaged.lua
+++ b/openwisp-config/tests/test_store_unmanaged.lua
@@ -2,9 +2,9 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-luaunit = require('luaunit')
-store_unmanaged = assert(loadfile("../files/sbin/openwisp-store-unmanaged.lua"))
-default_blocks = "system.ntp " ..
+local luaunit = require('luaunit')
+local store_unmanaged = assert(loadfile("../files/sbin/openwisp-store-unmanaged.lua"))
+local default_blocks = "system.ntp " ..
                  "system.@led " ..
                  "network.loopback " ..
                  "network.@globals " ..
@@ -12,10 +12,10 @@ default_blocks = "system.ntp " ..
                  "network.wan " ..
                  "network.@switch " ..
                  "network.@switch_vlan"
-write_dir = './unmanaged/'
-assertNotNil = luaunit.assertNotNil
-assertNil = luaunit.assertNil
-assertEquals = luaunit.assertEquals
+local write_dir = './unmanaged/'
+local assertNotNil = luaunit.assertNotNil
+local assertNil = luaunit.assertNil
+local assertEquals = luaunit.assertEquals
 
 local function _clean()
     os.remove(write_dir .. 'network')
@@ -37,27 +37,27 @@ end
 function TestStoreUnmanaged.test_default()
     store_unmanaged('--test=1', '-o=' .. default_blocks)
     -- ensure network config file has been created correctly
-    local file = io.open(write_dir .. 'network')
-    assertNotNil(file)
-    local contents = file:read('*all')
-    assertNotNil(string.find(contents, "config interface 'loopback'"))
-    assertNotNil(string.find(contents, "option ipaddr '127.0.0.1'"))
-    assertNotNil(string.find(contents, "option ula_prefix 'fd8e:f40a:6701::/48'"))
-    assertNotNil(string.find(contents, "config interface 'wan'"))
-    assertNotNil(string.find(contents, "config switch"))
-    assertNotNil(string.find(contents, "option vlan '2'"))
-    assertNotNil(string.find(contents, "option vlan '1'"))
-    assertNil(string.find(contents, "config interface 'wlan0'"))
-    assertNil(string.find(contents, "config interface 'wlan1'"))
+    local networkFile = io.open(write_dir .. 'network')
+    assertNotNil(networkFile)
+    local networkContents = networkFile:read('*all')
+    assertNotNil(string.find(networkContents, "config interface 'loopback'"))
+    assertNotNil(string.find(networkContents, "option ipaddr '127.0.0.1'"))
+    assertNotNil(string.find(networkContents, "option ula_prefix 'fd8e:f40a:6701::/48'"))
+    assertNotNil(string.find(networkContents, "config interface 'wan'"))
+    assertNotNil(string.find(networkContents, "config switch"))
+    assertNotNil(string.find(networkContents, "option vlan '2'"))
+    assertNotNil(string.find(networkContents, "option vlan '1'"))
+    assertNil(string.find(networkContents, "config interface 'wlan0'"))
+    assertNil(string.find(networkContents, "config interface 'wlan1'"))
     -- ensure system config file exists
-    local file = io.open(write_dir .. 'system')
-    assertNotNil(file)
-    local contents = file:read('*all')
-    assertNotNil(string.find(contents, "list server '1.openwrt.pool.ntp.org'"))
-    assertNotNil(string.find(contents, "config led 'led_usb1'"))
-    assertNotNil(string.find(contents, "config led 'led_usb2'"))
-    assertNotNil(string.find(contents, "config led 'led_wlan2g'"))
-    assertNil(string.find(contents, "option hostname 'OpenWrt'"))
+    local systemFile = io.open(write_dir .. 'system')
+    assertNotNil(systemFile)
+    local systemContents = systemFile:read('*all')
+    assertNotNil(string.find(systemContents, "list server '1.openwrt.pool.ntp.org'"))
+    assertNotNil(string.find(systemContents, "config led 'led_usb1'"))
+    assertNotNil(string.find(systemContents, "config led 'led_usb2'"))
+    assertNotNil(string.find(systemContents, "config led 'led_wlan2g'"))
+    assertNil(string.find(systemContents, "option hostname 'OpenWrt'"))
 end
 
 function TestStoreUnmanaged.test_specific_name()

--- a/openwisp-config/tests/test_uci_autoname.lua
+++ b/openwisp-config/tests/test_uci_autoname.lua
@@ -2,9 +2,9 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-luaunit = require('luaunit')
-name_anonymous_uci = assert(loadfile("../files/sbin/openwisp-uci-autoname.lua"))
-write_dir = './anonymous/'
+local luaunit = require('luaunit')
+local name_anonymous_uci = assert(loadfile("../files/sbin/openwisp-uci-autoname.lua"))
+local write_dir = './anonymous/'
 
 TestUciAutoname = {
     setUp = function()
@@ -26,38 +26,38 @@ TestUciAutoname = {
 function TestUciAutoname.test_default_behaviour()
     name_anonymous_uci('--test=1')
     -- check network
-    local file = io.open(write_dir .. 'network')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config switch 'switch"))
-    luaunit.assertNotNil(string.find(contents, "config switch_vlan 'switch0_vlan1"))
-    luaunit.assertNotNil(string.find(contents, "config switch_port 'switch0_port1"))
-    luaunit.assertNotNil(string.find(contents, "config globals 'globals"))
-    luaunit.assertNotNil(string.find(contents, "config route 'route1"))
-    luaunit.assertNotNil(string.find(contents, "config route 'route2"))
+    local networkFile = io.open(write_dir .. 'network')
+    luaunit.assertNotNil(networkFile)
+    local networkContents = networkFile:read('*all')
+    luaunit.assertNotNil(string.find(networkContents, "config switch 'switch"))
+    luaunit.assertNotNil(string.find(networkContents, "config switch_vlan 'switch0_vlan1"))
+    luaunit.assertNotNil(string.find(networkContents, "config switch_port 'switch0_port1"))
+    luaunit.assertNotNil(string.find(networkContents, "config globals 'globals"))
+    luaunit.assertNotNil(string.find(networkContents, "config route 'route1"))
+    luaunit.assertNotNil(string.find(networkContents, "config route 'route2"))
     -- ensure rest of config options are present
-    luaunit.assertNotNil(string.find(contents, "config interface 'loopback'"))
-    luaunit.assertNotNil(string.find(contents, "config interface 'lan'"))
+    luaunit.assertNotNil(string.find(networkContents, "config interface 'loopback'"))
+    luaunit.assertNotNil(string.find(networkContents, "config interface 'lan'"))
     -- check wireless
-    local file = io.open(write_dir .. 'wireless')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config wifi-iface 'wifi_wlan0", nil, true))
-    luaunit.assertNotNil(string.find(contents, "config wifi-iface 'wifi_wlan1", nil, true))
+    local wirelessFile = io.open(write_dir .. 'wireless')
+    luaunit.assertNotNil(wirelessFile)
+    local wirelessContents = wirelessFile:read('*all')
+    luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan0", nil, true))
+    luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan1", nil, true))
     -- check system
-    local file = io.open(write_dir .. 'system')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config system 'system'"))
-    luaunit.assertNotNil(string.find(contents, "config led 'led_test1'"))
+    local systemFile = io.open(write_dir .. 'system')
+    luaunit.assertNotNil(systemFile)
+    local systemContents = systemFile:read('*all')
+    luaunit.assertNotNil(string.find(systemContents, "config system 'system'"))
+    luaunit.assertNotNil(string.find(systemContents, "config led 'led_test1'"))
     -- ensure rest of config options are present
-    luaunit.assertNotNil(string.find(contents, "config timeserver 'ntp'"))
-    luaunit.assertNotNil(string.find(contents, "config led 'led_usb1'"))
+    luaunit.assertNotNil(string.find(systemContents, "config timeserver 'ntp'"))
+    luaunit.assertNotNil(string.find(systemContents, "config led 'led_usb1'"))
     -- check firewall
-    local file = io.open(write_dir .. 'firewall')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config defaults 'defaults'"))
+    local firewallFile = io.open(write_dir .. 'firewall')
+    luaunit.assertNotNil(firewallFile)
+    local firewallContents = firewallFile:read('*all')
+    luaunit.assertNotNil(string.find(firewallContents, "config defaults 'defaults'"))
 end
 
 os.exit(luaunit.LuaUnit.run())

--- a/openwisp-config/tests/test_update_bad_config.lua
+++ b/openwisp-config/tests/test_update_bad_config.lua
@@ -2,12 +2,12 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-luaunit = require('luaunit')
-update_config = assert(loadfile("../files/sbin/openwisp-update-config.lua"))
-write_dir = './update-test/'
-config_dir = write_dir .. 'etc/config/'
-openwisp_dir = './openwisp/'
-remote_config_dir = openwisp_dir .. 'remote/etc/config'
+local luaunit = require('luaunit')
+local update_config = assert(loadfile("../files/sbin/openwisp-update-config.lua"))
+local write_dir = './update-test/'
+local config_dir = write_dir .. 'etc/config/'
+local openwisp_dir = './openwisp/'
+local remote_config_dir = openwisp_dir .. 'remote/etc/config'
 
 TestBrokenConfig = {
     setUp = function()
@@ -30,13 +30,13 @@ TestBrokenConfig = {
 
 function TestBrokenConfig.test_update()
     update_config('--test=1')
-    local_system = io.open(config_dir..'/system')
+    local local_system = io.open(config_dir..'/system')
     luaunit.assertNotNil(local_system)
-    remote_system = io.open(remote_config_dir..'/system')
+    local remote_system = io.open(remote_config_dir..'/system')
     luaunit.assertNotNil(remote_system)
-    local_network = io.open(config_dir..'/network')
+    local local_network = io.open(config_dir..'/network')
     luaunit.assertNotNil(local_network)
-    remote_network = io.open(remote_config_dir..'/network')
+    local remote_network = io.open(remote_config_dir..'/network')
     luaunit.assertNotNil(local_system:read('*all'), remote_system:read('*all'))
     luaunit.assertNotNil(local_network:read('*all'), remote_network:read('*all'))
 end

--- a/openwisp-config/tests/test_update_config.lua
+++ b/openwisp-config/tests/test_update_config.lua
@@ -2,12 +2,12 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-luaunit = require('luaunit')
-update_config = assert(loadfile("../files/sbin/openwisp-update-config.lua"))
-write_dir = './update-test/'
-config_dir = write_dir .. 'etc/config/'
-openwisp_dir = './openwisp/'
-remote_config_dir = openwisp_dir .. 'remote/etc/config'
+local luaunit = require('luaunit')
+local update_config = assert(loadfile("../files/sbin/openwisp-update-config.lua"))
+local write_dir = './update-test/'
+local config_dir = write_dir .. 'etc/config/'
+local openwisp_dir = './openwisp/'
+local remote_config_dir = openwisp_dir .. 'remote/etc/config'
 
 TestUpdateConfig = {
     setUp = function()
@@ -40,54 +40,54 @@ TestUpdateConfig = {
 function TestUpdateConfig.test_update()
     update_config('--test=1')
     -- check network
-    local file = io.open(config_dir .. 'network')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config interface 'added'"))
-    luaunit.assertNotNil(string.find(contents, "option ifname 'added0'"))
+    local networkFile = io.open(config_dir .. 'network')
+    luaunit.assertNotNil(networkFile)
+    local networkContents = networkFile:read('*all')
+    luaunit.assertNotNil(string.find(networkContents, "config interface 'added'"))
+    luaunit.assertNotNil(string.find(networkContents, "option ifname 'added0'"))
     -- check system
-    local file = io.open(config_dir .. 'system')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertNotNil(string.find(contents, "config system 'system'"))
-    luaunit.assertNotNil(string.find(contents, "option custom 'custom'"))
-    luaunit.assertNotNil(string.find(contents, "option hostname 'update_config'"))
-    luaunit.assertNotNil(string.find(contents, "config new 'new'"))
-    luaunit.assertNotNil(string.find(contents, "option test 'test'"))
+    local systemFile = io.open(config_dir .. 'system')
+    luaunit.assertNotNil(systemFile)
+    local systemContents = systemFile:read('*all')
+    luaunit.assertNotNil(string.find(systemContents, "config system 'system'"))
+    luaunit.assertNotNil(string.find(systemContents, "option custom 'custom'"))
+    luaunit.assertNotNil(string.find(systemContents, "option hostname 'update_config'"))
+    luaunit.assertNotNil(string.find(systemContents, "config new 'new'"))
+    luaunit.assertNotNil(string.find(systemContents, "option test 'test'"))
     -- ensure rest of config options are present
-    luaunit.assertNotNil(string.find(contents, "config timeserver 'ntp'"))
-    luaunit.assertNotNil(string.find(contents, "list server '3.openwrt.pool.ntp.org'"))
+    luaunit.assertNotNil(string.find(systemContents, "config timeserver 'ntp'"))
+    luaunit.assertNotNil(string.find(systemContents, "list server '3.openwrt.pool.ntp.org'"))
     -- ensure test file is present
-    local file = io.open('./update-test/etc/test')
-    luaunit.assertNotNil(file)
-    local contents = file:read('*all')
-    luaunit.assertEquals(contents, 'test\n')
+    local testFile = io.open('./update-test/etc/test')
+    luaunit.assertNotNil(testFile)
+    local testContents = testFile:read('*all')
+    luaunit.assertEquals(testContents, 'test\n')
     -- ensure added.list is what we expect
-    local file = io.open(openwisp_dir .. '/added.list')
-    luaunit.assertNotNil(file)
+    local addedListFile = io.open(openwisp_dir .. '/added.list')
+    luaunit.assertNotNil(addedListFile)
     -- ensure test file is present
-    local contents = file:read('*all')
-    luaunit.assertEquals(contents, '/etc/test\n')
+    local addedListContents = addedListFile:read('*all')
+    luaunit.assertEquals(addedListContents, '/etc/test\n')
     -- ensure files are removed
     luaunit.assertNil(io.open(config_dir..'/wireless'))
     luaunit.assertNil(io.open(remote_config_dir..'/wireless'))
     -- ensure existing original file has been stored
-    local file = io.open(openwisp_dir .. '/modified.list')
-    luaunit.assertNotNil(file)
-    luaunit.assertEquals(file:read('*all'), '/etc/existing\n')
-    local file = io.open(openwisp_dir .. '/stored/etc/existing')
-    luaunit.assertNotNil(file)
-    luaunit.assertEquals(file:read('*all'), 'original\n')
+    local modifiedListFile = io.open(openwisp_dir .. '/modified.list')
+    luaunit.assertNotNil(modifiedListFile)
+    luaunit.assertEquals(modifiedListFile:read('*all'), '/etc/existing\n')
+    local storedExisitngFile = io.open(openwisp_dir .. '/stored/etc/existing')
+    luaunit.assertNotNil(storedExisitngFile)
+    luaunit.assertEquals(storedExisitngFile:read('*all'), 'original\n')
     -- ensure it has been modified
-    local file = io.open(write_dir .. '/etc/existing')
-    luaunit.assertNotNil(file)
-    luaunit.assertEquals(file:read('*all'), 'modified\n')
+    local existingFile = io.open(write_dir .. '/etc/existing')
+    luaunit.assertNotNil(existingFile)
+    luaunit.assertEquals(existingFile:read('*all'), 'modified\n')
     -- ensure file is removed
     luaunit.assertNil(io.open(write_dir .. '/etc/remove-me'))
     -- ensure file is restored
-    local file = io.open(write_dir..'/etc/restore-me')
-    luaunit.assertNotNil(file)
-    luaunit.assertEquals(file:read('*all'), 'restore-me\n')
+    local restoreFile = io.open(write_dir..'/etc/restore-me')
+    luaunit.assertNotNil(restoreFile)
+    luaunit.assertEquals(restoreFile:read('*all'), 'restore-me\n')
     luaunit.assertNil(io.open(openwisp_dir..'/stored/etc/restore-me'))
 end
 

--- a/openwisp-config/tests/test_utils.lua
+++ b/openwisp-config/tests/test_utils.lua
@@ -2,10 +2,10 @@
 package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
-uci = require('uci')
+local uci = require('uci')
 local utils = require('openwisp.utils')
-luaunit = require('luaunit')
-write_dir = './utils'
+local luaunit = require('luaunit')
+local write_dir = './utils'
 
 TestUtils = {
     setUp = function()
@@ -24,7 +24,7 @@ function TestUtils.test_starts_with_dot()
 end
 
 function TestUtils.test_write_uci_section_named()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.write_uci_section(u, 'network', {
         [".name"] = "globals",
         [".type"] = "globals",
@@ -40,7 +40,7 @@ function TestUtils.test_write_uci_section_named()
 end
 
 function TestUtils.test_write_uci_section_anon()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.write_uci_section(u, 'network', {
         [".anonymous"] = true,
         [".name"] = "cfg0c1ec7",
@@ -61,7 +61,7 @@ function TestUtils.test_write_uci_section_anon()
 end
 
 function TestUtils.test_write_uci_section_duplicate_list()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.write_uci_section(u, 'network', {
         [".name"] = "lan",
         [".type"] = "interface",
@@ -110,7 +110,7 @@ end
 
 function TestUtils.test_remove_uci_options()
     os.execute('cp ./config/network '..write_dir..'/network')
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.remove_uci_options(u, 'network', {
         [".name"] = "wlan1",
         [".type"] = "interface",
@@ -131,7 +131,7 @@ end
 
 function TestUtils.test_remove_uci_options_twice()
     os.execute('cp ./config/network '..write_dir..'/network')
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.remove_uci_options(u, 'network', {
         [".name"] = "wlan1",
         [".type"] = "interface",
@@ -171,7 +171,7 @@ function TestUtils.test_is_table_empty_false()
 end
 
 function TestUtils.test_merge_uci_option()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     -- prepare config
     utils.write_uci_section(u, 'network', {
         [".name"] = "wlan1",
@@ -203,7 +203,7 @@ function TestUtils.test_merge_uci_option()
 end
 
 function TestUtils.test_merge_uci_list()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     -- prepare config
     utils.write_uci_section(u, 'network', {
         [".name"] = "wlan1",
@@ -232,7 +232,7 @@ function TestUtils.test_merge_uci_list()
 end
 
 function TestUtils.test_merge_uci_list_duplicate()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     -- prepare config
     utils.write_uci_section(u, 'network', {
         [".name"] = "wlan1",
@@ -266,7 +266,7 @@ function TestUtils.test_dirtree()
     os.execute('touch '..write_dir..'/f2')
     os.execute('mkdir '..write_dir..'/inner')
     os.execute('touch '..write_dir..'/f3')
-    count = 0
+    local count = 0
     for filename, attr in utils.dirtree(write_dir) do
         count = count + 1
     end
@@ -282,7 +282,7 @@ function TestUtils.test_file_to_set()
     os.execute('echo "line1" > '..write_dir..'/read.list')
     os.execute('echo "line2" >> '..write_dir..'/read.list')
     os.execute('echo "line3" >> '..write_dir..'/read.list')
-    set = utils.file_to_set(write_dir..'/read.list')
+    local set = utils.file_to_set(write_dir..'/read.list')
     luaunit.assertEquals(set.line1, true)
     luaunit.assertEquals(set.line2, true)
     luaunit.assertEquals(set.line3, true)
@@ -290,17 +290,17 @@ function TestUtils.test_file_to_set()
 end
 
 function TestUtils.test_set_to_file()
-    write = {line1=true, line2=true}
-    result = utils.set_to_file(write, write_dir..'/write.list')
+    local write = {line1=true, line2=true}
+    local result = utils.set_to_file(write, write_dir..'/write.list')
     luaunit.assertEquals(result, true)
-    read = utils.file_to_set(write_dir..'/write.list')
+    local read = utils.file_to_set(write_dir..'/write.list')
     luaunit.assertEquals(read.line1, true)
     luaunit.assertEquals(read.line2, true)
     luaunit.assertEquals(read.line3, nil)
 end
 
 function TestUtils.test_split()
-    t = {'a', 'b', 'c'}
+    local t = {'a', 'b', 'c'}
     luaunit.assertEquals(utils.split('a b c'), t)
     luaunit.assertEquals(utils.split('a,b,c', ','), t)
     luaunit.assertEquals(utils.split('a/b/c', '/'), t)
@@ -321,17 +321,17 @@ function TestUtils.test_starts_with()
 end
 
 function TestUtils.test_sorted_pairs()
-    t = {b='b', z='z', a='a', m='m', g='g'}
-    list = {}
-    for key, value in utils.sorted_pairs(t) do
+    local t = {b='b', z='z', a='a', m='m', g='g'}
+    local list = {}
+    for _key, value in utils.sorted_pairs(t) do
         table.insert(list, value)
     end
-    expected = {'a', 'b', 'g', 'm', 'z'}
+    local expected = {'a', 'b', 'g', 'm', 'z'}
     luaunit.assertEquals(list, expected)
 end
 
 function TestUtils.test_write_uci_section_order()
-    u = uci.cursor(write_dir)
+    local u = uci.cursor(write_dir)
     utils.write_uci_section(u, 'network', {
         [".name"] = "globals",
         [".type"] = "globals",
@@ -344,7 +344,7 @@ function TestUtils.test_write_uci_section_order()
     local file = io.open(write_dir .. '/network')
     luaunit.assertNotNil(file)
     local contents = file:read('*all')
-    expected = "\toption aaaaaa 'should come first'\n" ..
+    local expected = "\toption aaaaaa 'should come first'\n" ..
                "\toption ula_prefix 'fd8e:f40a:fede::/48'\n" ..
                "\toption zzzzzz 'just a test'"
     luaunit.assertNotNil(string.find(contents, expected))

--- a/runtests
+++ b/runtests
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
+luacheck . -a
 cd openwisp-config/tests/
-luacheck . -d -a -r
 lua test_store_unmanaged.lua -v
 lua test_restore_unmanaged.lua -v
 lua test_uci_autoname.lua -v


### PR DESCRIPTION
Removes all filter flags from luacheck, and ensure it runs over the whole codebase
Fix all luacheck warnings that arise from this.
Closes #77 