### PR TITLE
Show entire error message in logs on failed auto-registration #42

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -187,7 +187,8 @@ register() {
 	check_header $REGISTRATION_PARAMETERS
 	# exit if controller returns errors
 	if [ $(head -n 1 $REGISTRATION_PARAMETERS | grep -c "201 Created") -lt 1 ]; then
-		local message=$(tail -n 1 $REGISTRATION_PARAMETERS)
+		# get body of failure response, seperated from header by a blank line (CRLF-ended)
+		local message=$(awk 'BEGIN{RS="\r\n\r\n"}{if(NR>1)print $0}' $REGISTRATION_PARAMETERS)
 		logger -s "Registration failed! $message" \
 			   -t openwisp \
 			   -p daemon.err


### PR DESCRIPTION
Show entire error message in logs instead of the last line only on failed auto-registration, Fixes #42