### PR TITLE
[agent] Give up registration only when 403

### DIFF
--- a/openwisp-config/Makefile
+++ b/openwisp-config/Makefile
@@ -21,7 +21,7 @@ define Package/openwisp-config/default
 	DEPENDS:=+curl +lua +libuci-lua +luafilesystem $(3)
 	VARIANT:=$(1)
 	PKGARCH:=all
-	MAINTAINER:=Federico Capoano <nemesis@ninux.org>
+	MAINTAINER:=Federico Capoano <federico.capoano@gmail.com>
 	URL:=http://openwisp.org
 endef
 

--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -188,13 +188,20 @@ register() {
 	fi
 	# exit if response does not seem to come from openwisp controller
 	check_header $REGISTRATION_PARAMETERS
-	# exit if controller returns errors
 	if [ $(head -n 1 $REGISTRATION_PARAMETERS | grep -c "201 Created") -lt 1 ]; then
 		local message=$(tail -n 1 $REGISTRATION_PARAMETERS)
 		logger -s "Registration failed! $message" \
 			   -t openwisp \
 			   -p daemon.err
-		exit 5
+		# if controller returns 403, stop retrying because it's useless
+		if [ $(head -n 1 $REGISTRATION_PARAMETERS | grep -c "403 Forbidden") -gt 0 ]; then
+			exit 5
+		# in all other cases, keep re-trying because the problem can be fixed
+		# on the server (eg: self creation disabled and device needs to be created
+		# or temporary error condition on the server)
+		else
+			return 2
+		fi
 	fi
 	# set configuration options and reload
 	export UUID=$(cat $REGISTRATION_PARAMETERS | grep uuid | awk '/uuid: / { print $2 }')


### PR DESCRIPTION
Give up registration only when 403, keep retrying in all other cases.

This allows the device to keep trying to register if there's a temporary server side issue or in case the self creation has been disabled: https://github.com/openwisp/django-netjsonconfig/pull/162
