### PR TITLE
[setup] fixed install & runtests scripts

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -9,13 +9,13 @@ apt-get install -y cmake git-core
 apt-get install -y lua5.1 liblua5.1-0-dev luarocks
 # install json-c
 apt-get install -y dh-autoreconf
-git clone https://github.com/json-c/json-c.git --depth=1 && cd json-c
-sh autogen.sh && ./configure && make && make install && cd ..
+git clone https://github.com/json-c/json-c.git --depth=1
+cd json-c  && cmake . && make install && cd ..  || { echo 'Installing json-c failed!' ; exit 1; }
 # install openwrt libubox and uci
-git clone https://git.openwrt.org/project/libubox.git --depth=1 && cd libubox
-cmake . && make install && cd ..
-git clone https://git.openwrt.org/project/uci.git --depth=1 && cd uci
-cmake . && make install && cd ..
+git clone https://git.openwrt.org/project/libubox.git --depth=1
+cd libubox && cmake . && make install && cd .. || { echo 'Installing libubox failed!' ; exit 1; }
+git clone https://git.openwrt.org/project/uci.git --depth=1
+cd uci     && cmake . && make install && cd .. || { echo 'Installing uci failed!' ; exit 1; }
 # update links to shared libraries
 ldconfig -v
 # install luafilesystem

--- a/runtests
+++ b/runtests
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-luacheck . -a
+luacheck ./openwisp-config/ -a
 cd openwisp-config/tests/
 lua test_store_unmanaged.lua -v
 lua test_restore_unmanaged.lua -v


### PR DESCRIPTION
Fixed setup problems.
1. In `install-dev.sh` installation procedure of json-c needed to be updated. :-)

2. Failing chained commands were not stopping the install script immediately, changed that by using `command || {exit 1}` trick.

3. In `./runtests` scripts, changed `luacheck . -a` -> `luacheck ./openwisp-config/ -a` because if I do `./runbuild` with BUILD_DIR as `~/.build`, runtests wouldn't work again, I suppose other developers would want to build for testing in this directory itself as well, hence made this change.
Let me know if BUILD_DIR should be elsewhere and I should reverse this change.

Closes #105 