### PR TITLE
[agent] Case sensitivity when checking header #110

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -118,7 +118,7 @@ get_system(){ ubus call system board | grep system | awk -F\" '{ print $4 }'; }
 
 # ensures we are dealing with the right web server
 check_header(){
-	local is_controller=$(grep -c "X-Openwisp-Controller: true" $1)
+	local is_controller=$(grep -ic "X-Openwisp-Controller: true" $1)
 	if [ $is_controller -lt 1 ]; then
 		logger -s "Invalid url: missing X-Openwisp-Controller header" \
 			   -t openwisp \


### PR DESCRIPTION
If the headers get changed, the check was case sensitive. That
prevented the client from connecting. This changes the check to be
case insensitive instead.

Fixes #110