### PR TITLE
[agent] Add config options post_reload_delay and test_retries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ UCI configuration options must go in ``/etc/config/openwisp``.
 - ``consistent_key``: whether `Consistent key generation`_ is enabled or not, defaults to ``1``
 - ``merge_config``: whether `Merge configuration`_ is enabled or not, defaults to ``1``
 - ``test_config``: whether a new configuration must be tested before being considered applied, defaults to ``1``
+- ``test_retries``: maximum number of retries when doing the default configuration test, defaults to ``3``
 - ``test_script``: custom test script, read more about this feature in `Configuration test`_
 - ``uuid``: unique identifier of the router configuration in the controller application
 - ``key``: key required to download the configuration
@@ -93,6 +94,7 @@ UCI configuration options must go in ``/etc/config/openwisp``.
   (new device will be named after its mac address, to avoid having many new devices with the same name)
 - ``pre_reload_hook``: path to custom executable script, see `pre-reload-hook`_
 - ``post_reload_hook``: path to custom executable script, see `post-reload-hook`_
+- ``post_reload_delay``: delay in seconds to wait before the post-reload-hook and any configuration test, defaults to ``0``
 - ``post_registration_hook``: path to custom executable script, see `post-registration-hook`_
 
 Automatic registration

--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -17,6 +17,7 @@ while [ -n "$1" ]; do
 		--merge-config) export MERGE_CONFIG="$2"; shift;;
 		--unmanaged) export UNMANAGED="$2"; shift;;
 		--test-config) export TEST_CONFIG="$2"; shift;;
+		--test-retries) export TEST_RETRIES="$2"; shift;;
 		--test-script) export TEST_SCRIPT="$2"; shift;;
 		--connect-timeout) export CONNECT_TIMEOUT="$2"; shift;;
 		--max-time) export MAX_TIME="$2"; shift;;
@@ -27,6 +28,7 @@ while [ -n "$1" ]; do
 		--default-hostname) export DEFAULT_HOSTNAME="$2"; shift;;
 		--pre-reload-hook) export PRE_RELOAD_HOOK="$2"; shift;;
 		--post-reload-hook) export POST_RELOAD_HOOK="$2"; shift;;
+		--post-reload-delay) export POST_RELOAD_DELAY="$2"; shift;;
 		--post-registration-hook) export POST_REGISTRATION_HOOK="$2"; shift;;
 		-*)
 			echo "Invalid option: $1"
@@ -61,6 +63,7 @@ INTERVAL=${INTERVAL:-120}
 VERIFY_SSL=${VERIFY_SSL:-1}
 MERGE_CONFIG=${MERGE_CONFIG:-1}
 TEST_CONFIG=${TEST_CONFIG:-1}
+TEST_RETRIES=${TEST_RETRIES:-3}
 CONSISTENT_KEY=${CONSISTENT_KEY:-1}
 HARDWARE_ID_KEY=${HARDWARE_ID_KEY:-1}
 BOOTUP_DELAY=${BOOTUP_DELAY:-0}
@@ -72,6 +75,7 @@ MAC_INTERFACE=${MAC_INTERFACE:-eth0}
 DEFAULT_HOSTNAME=${DEFAULT_HOSTNAME:-"LEDE"}
 PRE_RELOAD_HOOK=${PRE_RELOAD_HOOK:-/etc/openwisp/pre-reload-hook}
 POST_RELOAD_HOOK=${POST_RELOAD_HOOK:-/etc/openwisp/post-reload-hook}
+POST_RELOAD_DELAY=${POST_RELOAD_DELAY:-5}
 POST_REGISTRATION_HOOK=${POST_REGISTRATION_HOOK:-/etc/openwisp/post-registration-hook}
 WORKING_DIR="/tmp/openwisp"
 BASEURL="$URL/controller"
@@ -323,7 +327,6 @@ post_registration_hook() {
 
 # applies a specified configuration archive
 apply_configuration() {
-	local sleep_time=${2-5}
 	# store unmanaged config (if enabled)
 	call_store_unmanaged
 	# update local configuration
@@ -342,9 +345,9 @@ apply_configuration() {
 	fi
 	# call pre-reload-hook
 	pre_reload_hook
-	# reload changes and wait $sleep_time
+	# reload changes and wait $POST_RELOAD_DELAY
 	/usr/sbin/openwisp-reload-config
-	sleep $sleep_time
+	sleep $POST_RELOAD_DELAY
 	# call post-reload-hook
 	post_reload_hook
 }
@@ -460,11 +463,14 @@ test_configuration() {
 }
 
 perform_default_test() {
-	# max 3 attempts to get checksum
-	for i in $(seq 1 3); do
+	# the default test is performed several times, as indicated by $TEST_RETRIES
+	for i in $(seq 1 $TEST_RETRIES); do
 		$($FETCH_COMMAND -i --connect-timeout 5 --max-time 5 $CHECKSUM_URL > $TEST_CHECKSUM)
 		local result=$?
 		if [ $result -gt 0 ]; then
+			logger "Configuration test try $i failed" \
+			       -t openwisp \
+			       -p daemon.warning
 			sleep 5
 		else
 			break
@@ -575,7 +581,7 @@ restore_backup() {
 	sysupgrade -r $CONFIGURATION_BACKUP
 	pre_reload_hook
 	/usr/sbin/openwisp-reload-config
-	sleep 2
+	sleep $POST_RELOAD_DELAY
 	post_reload_hook
 	logger -s "The most recent configuration backup was restored" \
 	       -t openwisp \

--- a/openwisp-config/files/openwisp.init
+++ b/openwisp-config/files/openwisp.init
@@ -21,6 +21,7 @@ start_service() {
 	unmanaged=$(config_get http unmanaged)
 	merge_config=$(config_get http merge_config)
 	test_config=$(config_get http test_config)
+	test_retries=$(config_get http test_retries)
 	test_script=$(config_get http test_script)
 	connect_timeout=$(config_get http connect_timeout)
 	max_time=$(config_get http max_time)
@@ -31,6 +32,7 @@ start_service() {
 	default_hostname=$(config_get http default_hostname)
 	pre_reload_hook=$(config_get http pre_reload_hook)
 	post_reload_hook=$(config_get http post_reload_hook)
+	post_reload_delay=$(config_get http post_reload_delay)
 	post_registration_hook=$(config_get http post_registration_hook)
 	if [ $url ]; then url="--url $url"; fi
 	if [ $interval ]; then interval="--interval $interval"; fi
@@ -50,6 +52,7 @@ start_service() {
 	fi
 	if [ $merge_config ]; then merge_config="--merge-config $merge_config"; fi
 	if [ $test_config ]; then test_config="--test-config $test_config"; fi
+	if [ $test_retries ]; then test_retries="--test-retries $test_retries"; fi
 	if [ $test_script ]; then test_script="--test-script $test_script"; fi
 	if [ $connect_timeout ]; then connect_timeout="--connect-timeout $connect_timeout"; fi
 	if [ $max_time ]; then max_time="--max-time $max_time"; fi
@@ -60,6 +63,7 @@ start_service() {
 	if [ $default_hostname ]; then default_hostname="--default-hostname $default_hostname"; fi
 	if [ $pre_reload_hook ]; then pre_reload_hook="--pre-reload-hook $pre_reload_hook"; fi
 	if [ $post_reload_hook ]; then post_reload_hook="--post-reload-hook $post_reload_hook"; fi
+	if [ $post_reload_delay ]; then post_reload_delay="--post-reload-delay $post_reload_delay"; fi
 	if [ $post_registration_hook ]; then post_registration_hook="--post-registration-hook $post_registration_hook"; fi
 
 	if [ -z "$url" ]; then
@@ -80,9 +84,10 @@ start_service() {
 	procd_set_param command $PROG $url $interval $verify_ssl $uuid $key $shared_secret \
 	                        $consistent_key $hardware_id_script $hardware_id_key \
 	                        $bootup_delay $unmanaged $merge_config $test_config \
-	                        $test_script $connect_timeout $max_time $capath $cacert \
-	                        $mac_interface $management_interface $default_hostname \
-	                        $pre_reload_hook $post_reload_hook $post_registration_hook
+	                        $test_retries $test_script $connect_timeout $max_time $capath \
+	                        $cacert $mac_interface $management_interface $default_hostname \
+	                        $pre_reload_hook $post_reload_hook $post_reload_delay \
+	                        $post_registration_hook
 	procd_set_param respawn
 	procd_close_instance
 	logger -s "$PROG_NAME started" \


### PR DESCRIPTION
This patch adds 2 config options for the default config test.

1. `test_delay` is a time in seconds to wait after applying the configuration before the config test is started. This prevents that the test is successfully completed before the change is even applied by the services.
2. `test_retries` is the number of retries used by the test. Applying configuration changes can take quite some time (for example enabling a wwan connection with trying several networks) and in such cases the config test would fail after 3 retries with the configuration change not even fully applied by the services.