### PR TITLE
[agent] Use configured curl timeout values in default test

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -465,7 +465,7 @@ test_configuration() {
 perform_default_test() {
 	# the default test is performed several times, as indicated by $TEST_RETRIES
 	for i in $(seq 1 $TEST_RETRIES); do
-		$($FETCH_COMMAND -i --connect-timeout 5 --max-time 5 $CHECKSUM_URL > $TEST_CHECKSUM)
+		$($FETCH_COMMAND -i $CHECKSUM_URL > $TEST_CHECKSUM)
 		local result=$?
 		if [ $result -gt 0 ]; then
 			logger "Configuration test failed (attempt $i)" \


### PR DESCRIPTION
Otherwise it's possible that the test fails although the regular checksum fetch succeeds.

I had this issue because the overridden value 5 for `--connect-timeout` and `--max-time` was too low for the specific connection of the device.

In general it makes sense that the test behaves exactly like the regular checksum fetch.