### PR TITLE
[fix] Ensured config download error is detected #125

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -519,7 +519,7 @@ update_configuration() {
 		   -p daemon.info
 
 	# download configuration
-	$($FETCH_COMMAND $CONFIGURATION_URL -o $CONFIGURATION_ARCHIVE)
+	$($FETCH_COMMAND --fail $CONFIGURATION_URL -o $CONFIGURATION_ARCHIVE)
 	local exit_code=$?
 
 	if [ "$exit_code" != "0" ]; then


### PR DESCRIPTION
Adding the --fail flag to curl makes it exit with a non zero
exit code in case the server respond with an HTTP status code
which is not 200 OK.

Without this fix, a bad response is interpreted as a valid configuration
and the agent removes the old configuration, then installs the new configuration,
which fails and the router remains with an empty configuration,
effectively causing a disrupation of service.

Fixes #125