### PR TITLE
[fix] Avoid assigning an existing name to an unnamed config

### DIFF
--- a/openwisp-config/files/sbin/openwisp-uci-autoname.lua
+++ b/openwisp-config/files/sbin/openwisp-uci-autoname.lua
@@ -18,22 +18,23 @@ local standard_path = standard_prefix .. (test and 'anonymous' or 'config')
 local standard = uci.cursor(standard_path) -- read operations
 local output = standard  -- write operations
 local stdout = ''  -- result
-local count = {}
-
-local function getCount(type)
-    return count[type]
-end
-
-local function incCount(type)
-    if count[type] == nil then
-        count[type] = 1
-    else
-        count[type] = count[type] + 1
-    end
-end
+local new_name = ''
+local all_names = {}
 
 local function getUCIName(name)
     return string.gsub(string.gsub(name, '%.', '_'), '-', '_')
+end
+
+local function nextAvailableName(type)
+    -- first available name in the form of
+    -- 'type .. increment' with increment starting from 1
+    local i = 1
+    local name = type .. i
+    while all_names[name] do
+        i = i + 1
+        name = type .. i
+    end
+    return name
 end
 
 -- if test mode
@@ -47,37 +48,47 @@ end
 for file in lfs.dir(standard_path) do
     if file ~= '.' and file ~= '..' then
         local changed = false
+        -- avoid overwites by storing all existing names
+        standard:foreach(file, nil, function(section)
+            if not section['.anonymous'] then
+                all_names[section['.name']] = true
+            end
+        end)
         standard:foreach(file, nil, function(section)
             local index = section['.index']
             if section['.anonymous'] then
                 output:delete(file, section['.name'])
                 if file == 'firewall' and section['.type'] == 'defaults' then
-                    section['.name'] = 'defaults'
+                    new_name = 'defaults'
                 elseif file == 'network' and section['.type'] == 'globals' then
-                    section['.name'] = 'globals'
+                    new_name = 'globals'
                 elseif file == 'network' and (section['.type'] == 'route' or section['.type'] == 'route6') then
-                    incCount('route')
-                    section['.name'] = 'route' .. getCount('route')
+                    new_name = nextAvailableName('route')
                 elseif file == 'network' and section['.type'] == 'switch' then
-                    section['.name'] = section['name']
+                    new_name = section['name']
                 elseif file == 'network' and section['.type'] == 'switch_vlan' then
-                    section['.name'] = section['device'] .. '_vlan' .. section['vlan']
+                    new_name = section['device'] .. '_vlan' .. section['vlan']
                 elseif file == 'network' and section['.type'] == 'switch_port' then
-                    section['.name'] = section['device'] .. '_port' .. section['port']
+                    new_name = section['device'] .. '_port' .. section['port']
                 elseif file == 'system' and section['.type'] == 'system' then
-                    section['.name'] = 'system'
+                    new_name = 'system'
                 elseif file == 'system' and section['.type'] == 'led' then
-                    section['.name'] = 'led_' .. string.lower(section['name'])
+                    new_name = 'led_' .. string.lower(section['name'])
                 elseif file == 'wireless' and section['.type'] == 'wifi-iface' then
                     if section['ifname'] == nil then
-                        section['.name'] = 'wifi_' .. getUCIName(standard:get('network', section['network'], 'ifname'))
+                        new_name = 'wifi_' .. getUCIName(standard:get('network', section['network'], 'ifname'))
                     else
-                        section['.name'] = 'wifi_' .. getUCIName(section['ifname'])
+                        new_name = 'wifi_' .. getUCIName(section['ifname'])
                     end
                 else
-                    incCount(section['.type'])
-                    section['.name'] = getUCIName(section['.type']) .. getCount(section['.type'])
+                    new_name = nextAvailableName(getUCIName(section['.type']))
                 end
+                -- make sure the new name is unique
+                if all_names[new_name] then
+                    new_name = nextAvailableName(new_name .. '_')
+                end
+                all_names[new_name] = true
+                section['.name'] = new_name
                 section['.anonymous'] = false
                 utils.write_uci_section(output, file, section)
                 output:reorder(file, section['.name'], index)

--- a/openwisp-config/tests/config/network
+++ b/openwisp-config/tests/config/network
@@ -50,7 +50,7 @@ config switch_port
 	option device 'switch0'
 	option port '1'
 
-config route
+config route 'route1'
   option test '1'
 
 config route


### PR DESCRIPTION
Fixes #136
The algorithm for renaming anonymous configurations would assign the name of an existing named one if 
this appeared before the anonymous in the configuration file.

For example:
config route 'route1'
        option test '1'
config route
        option test '2'

would result in:
config route 'route1'
        option test '2'

The new algorithm first collects all named configs. When an unnamed config occurs, the new name is obtained and checked if it already exists. If it does, a suffix '_{counter}' is appended to the name.
In cases where the incCount() was used (route), a new function is implemented (nextAvailableName()) that does a similar work but avoids using an existing name. 

Altered the checks accordingly.