### PR TITLE
[fix] Fixed register bug when mac_interface is not present

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -278,7 +278,7 @@ register() {
 		params keybase consistent_key exit_code message new prefix
 	hostname=$(uci get system.@system[0].hostname)
 	# use macaddr of interface specified in $MAC_INTERFACE
-	raw=$(ifconfig "$MAC_INTERFACE" 2>/dev/null 2>&1)
+	raw=$(ifconfig "$MAC_INTERFACE" 2>/dev/null)
 	# if previous command fails, fallback to first non-loopback interface
 	if [ -z "$raw" ]; then raw=$(ifconfig); fi
 	macaddr=$(echo "$raw " | grep -E -v "^(lo|tap[0-9]+)" | awk '/HWaddr/ { print $5 }' | head -n 1)


### PR DESCRIPTION
If the interface specified in the mac_interface is not available on the system, the agent should take the first non-loopback interface available, but this behavior was broken inadvertently.