### PR TITLE
[change] Changed naming of agent file and init for consistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ and `Compiling a custom OpenWRT image`_.
 Once installed *openwisp-config* needs to be configured (see `Configuration options`_)
 and then started with::
 
-    /etc/init.d/openwisp_config start
+    /etc/init.d/openwisp-config start
 
 To ensure the agent is working correctly find out how to perform debugging in
 the `Debugging`_ section.
@@ -188,7 +188,7 @@ If the test fails, the backup is restored and the agent will log the failure via
 Disable testing
 ^^^^^^^^^^^^^^^
 
-To disable this feature, set the ``test_config`` option to ``0``, then reload/restart *openwisp_config*.
+To disable this feature, set the ``test_config`` option to ``0``, then reload/restart *openwisp-config*.
 
 Define custom tests
 ^^^^^^^^^^^^^^^^^^^
@@ -238,7 +238,7 @@ In some cases it could be necessary to ensure that some configuration sections w
 overwritten by the controller.
 
 These settings are called "unmanaged", in the sense that they are not managed remotely.
-In the default configuration of *openwisp_config* there are no unmanaged settings.
+In the default configuration of *openwisp-config* there are no unmanaged settings.
 
 Example unmanaged settings::
 
@@ -297,7 +297,7 @@ Complete example:
     EOF
     # make script executable
     chmod +x /usr/sbin/my-pre-reload-hook
-    # reload openwisp_config by using procd's convenient utility
+    # reload openwisp-config by using procd's convenient utility
     reload_config
 
 post-reload-hook
@@ -468,11 +468,11 @@ If you are in doubt openwisp-config is running at all, you can check with::
 
 You should see something like::
 
-    3800 root      1200 S    {openwisp_config} /bin/sh /usr/sbin/openwisp_config --url https://openwisp2.mydomain.com --verify-ssl 1 --consistent-key 1 ...
+    3800 root      1200 S    {openwisp-config} /bin/sh /usr/sbin/openwisp-config --url https://openwisp2.mydomain.com --verify-ssl 1 --consistent-key 1 ...
 
 You can inspect the version of openwisp-config currently installed with::
 
-    openwisp_config --version
+    openwisp-config --version
 
 Quality Assurance Checks
 ------------------------

--- a/openwisp-config/Makefile
+++ b/openwisp-config/Makefile
@@ -42,11 +42,11 @@ define Package/openwisp-config/install
 
 	$(INSTALL_BIN) \
 		files/openwisp.agent \
-		$(1)/usr/sbin/openwisp_config
+		$(1)/usr/sbin/openwisp-config
 
 	$(INSTALL_BIN) \
 		files/openwisp.init \
-		$(1)/etc/init.d/openwisp_config
+		$(1)/etc/init.d/openwisp-config
 
 	$(INSTALL_CONF) files/openwisp.config \
 		$(1)/etc/config/openwisp
@@ -92,6 +92,24 @@ define Package/openwisp-config/install
 		$(1)/usr/sbin/openwisp-get-random-number
 
 	$(CP) ../VERSION $(1)/usr/lib/openwisp-config/
+endef
+
+# for backward compatibility
+define Package/openwisp-config/postinst
+#!/bin/sh
+if [ ! -L /usr/sbin/openwisp_config ]; then
+	ln -s /usr/sbin/openwisp-config /usr/sbin/openwisp_config
+fi
+
+if [ ! -L /etc/init.d/openwisp_config ]; then
+	ln -s /etc/init.d/openwisp-config /etc/init.d/openwisp_config
+fi
+endef
+
+define Package/openwisp-config/postrm
+#!/bin/sh
+rm -f /usr/sbin/openwisp_config
+rm -f /etc/init.d/openwisp-config
 endef
 
 $(eval $(call BuildPackage,openwisp-config))

--- a/openwisp-config/Makefile
+++ b/openwisp-config/Makefile
@@ -109,7 +109,7 @@ endef
 define Package/openwisp-config/postrm
 #!/bin/sh
 rm -f /usr/sbin/openwisp_config
-rm -f /etc/init.d/openwisp-config
+rm -f /etc/init.d/openwisp_config
 endef
 
 $(eval $(call BuildPackage,openwisp-config))

--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -584,7 +584,7 @@ print_error_logs() {
 	# "\n[truncated]" is appended to the logs which adds
 	# another 13 bytes.
 	max_log_bytes=1011
-	# Save openwisp_config related logs to a temporary file
+	# Save openwisp-config related logs to a temporary file
 	logread -e openwisp >"$CONFIG_ERROR_LOG"
 	# Get the line number of the last configuration update
 	last_update_line_no=$(

--- a/openwisp-config/files/openwisp.init
+++ b/openwisp-config/files/openwisp.init
@@ -7,7 +7,7 @@
 	START=99
 	USE_PROCD=1
 }
-PROG="/usr/sbin/openwisp_config"
+PROG="/usr/sbin/openwisp-config"
 PROG_NAME="OpenWISP config agent"
 CONTROL_FILE=/tmp/openwisp/applying_conf
 

--- a/openwisp-config/files/sbin/openwisp-reload-config
+++ b/openwisp-config/files/sbin/openwisp-reload-config
@@ -1,5 +1,5 @@
 #!/bin/sh
-# openwisp_config variant of /sbin/reload_config
+# openwisp-config variant of /sbin/reload_config
 
 rm -rf /var/run/config.check
 mkdir -p /var/run/config.check


### PR DESCRIPTION
The name "openwisp_config" wasn't consistent with all the other files of the package.

A symbolic link to the old files is provided for backward compatibility.