### PR TITLE
[fix] Fix postinst/postrm in Makefile

### DIFF
--- a/openwisp-config/Makefile
+++ b/openwisp-config/Makefile
@@ -97,19 +97,19 @@ endef
 # for backward compatibility
 define Package/openwisp-config/postinst
 #!/bin/sh
-if [ ! -L /usr/sbin/openwisp_config ]; then
-	ln -s /usr/sbin/openwisp-config /usr/sbin/openwisp_config
+if [ ! -L $${IPKG_INSTROOT}/usr/sbin/openwisp_config ]; then
+	ln -s /usr/sbin/openwisp-config $${IPKG_INSTROOT}/usr/sbin/openwisp_config
 fi
 
-if [ ! -L /etc/init.d/openwisp_config ]; then
-	ln -s /etc/init.d/openwisp-config /etc/init.d/openwisp_config
+if [ ! -L $${IPKG_INSTROOT}/etc/init.d/openwisp_config ]; then
+	ln -s /etc/init.d/openwisp-config $${IPKG_INSTROOT}/etc/init.d/openwisp_config
 fi
 endef
 
 define Package/openwisp-config/postrm
 #!/bin/sh
-rm -f /usr/sbin/openwisp_config
-rm -f /etc/init.d/openwisp_config
+rm -f $${IPKG_INSTROOT}/usr/sbin/openwisp_config
+rm -f $${IPKG_INSTROOT}/etc/init.d/openwisp_config
 endef
 
 $(eval $(call BuildPackage,openwisp-config))


### PR DESCRIPTION
The postinst/postrm directives must use `IPKG_INSTROOT` because they are executed by the image builder as well.

See: 

* https://github.com/openwrt/packages/blob/master/utils/zsh/Makefile#L101 as an example
* https://openwrt.org/docs/techref/initscripts#enable_and_disable for initscripts