### PR TITLE
Fixes #224: Added ipv6 support to `openwisp-get-address`

### DIFF
--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -1,32 +1,16 @@
 #!/usr/bin/env lua
 
 -- gets the first useful address of the specified interface
--- fistly tries to get an IPv4 address, if not found, tries to get an IPv6 address
--- with the --prefer-ipv6 option, it will try to get an IPv6 address first
 -- usage:
---   * openwisp-get-address <ifname> [--prefer-ipv6]
---   * openwisp-get-address <network-name> [--prefer-ipv6]
+--   * openwisp-get-address <ifname>
+--   * openwisp-get-address <network-name>
 local os = require('os')
 local net = require('openwisp.net')
 local name = arg[1]
-local prefer_ipv6 = arg[2] == "--prefer-ipv6"
-
-local ip_version1, ip_version2
-
-if prefer_ipv6 then
-  ip_version1 = 'inet6'
-  ip_version2 = 'inet'
-else
-  ip_version1 = 'inet'
-  ip_version2 = 'inet6'
-end
-
-
-local interface = net.get_interface(name, ip_version1)
+local interface = net.get_interface(name, 'inet')
 if not interface then
-  interface = net.get_interface(name, ip_version2)
+  interface = net.get_interface(name, 'inet6')
 end
-
 
 if interface then
   print(interface.addr)

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -1,13 +1,32 @@
 #!/usr/bin/env lua
 
 -- gets the first useful address of the specified interface
+-- fistly tries to get an IPv4 address, if not found, tries to get an IPv6 address
+-- with the --prefer-ipv6 option, it will try to get an IPv6 address first
 -- usage:
---   * openwisp-get-address <ifname>
---   * openwisp-get-address <network-name>
+--   * openwisp-get-address <ifname> [--prefer-ipv6]
+--   * openwisp-get-address <network-name> [--prefer-ipv6]
 local os = require('os')
 local net = require('openwisp.net')
 local name = arg[1]
-local interface = net.get_interface(name)
+local prefer_ipv6 = arg[2] == "--prefer-ipv6"
+
+local ip_version1, ip_version2
+
+if prefer_ipv6 then
+  ip_version1 = 'inet6'
+  ip_version2 = 'inet'
+else
+  ip_version1 = 'inet'
+  ip_version2 = 'inet6'
+end
+
+
+local interface = net.get_interface(name, ip_version1)
+if not interface then
+  interface = net.get_interface(name, ip_version2)
+end
+
 
 if interface then
   print(interface.addr)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Fixes [#224](https://github.com/openwisp/openwisp-config/issues/224).

## Description of Changes
* Added support for getting the IPv6 address if the IPv4 address is not found in `openwisp-get-address`.