### PR TITLE
Rfc6724 use ipv6 as default

### DIFF
--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -4,7 +4,7 @@ local net = {}
 
 function net.get_interface(name, family)
   local uci_cursor = uci.cursor()
-  local ip_family = family or 'inet'
+  local ip_family = family or 'inet6'
   -- if UCI network name is a bridge, the ifname won't be the name of the bridge
   local is_bridge = uci_cursor:get('network', name, 'type') == 'bridge'
   local ifname

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -2,7 +2,7 @@ local nixio = require('nixio')
 local uci = require('uci')
 local net = {}
 
-function net.get_interface(name, family)
+function net.get_interface(name, family, ula)
   local uci_cursor = uci.cursor()
   local ip_family = family or 'inet6'
   -- if UCI network name is a bridge, the ifname won't be the name of the bridge
@@ -23,7 +23,17 @@ function net.get_interface(name, family)
   end)
   for _, interface in pairs(interfaces) do
     if interface.name == ifname and interface.family == ip_family then
-      return interface
+      if ip_family == 'inet6' then
+        if not string.match(interface.addr,'fe',0) then
+          if not ula and not string.match(interface.addr,'fd',0) then
+            return interface
+          elseif ula then
+            return interface
+          end
+        end
+      else
+        return interface
+      end
     end
   end
   -- return nil if nothing is found

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -4,7 +4,18 @@ local net = {}
 
 function net.get_interface(name, family, ula)
   local uci_cursor = uci.cursor()
-  local ip_family = family or 'inet6'
+  local ip_family
+  if family == 'inet' then
+    ip_family = 'inet'
+  else
+    ip_family = 'inet6'
+  end
+  local ip_ula
+  if ula == '1' then
+    ip_ula = true
+  else
+    ip_ula = false
+  end
   -- if UCI network name is a bridge, the ifname won't be the name of the bridge
   local is_bridge = uci_cursor:get('network', name, 'type') == 'bridge'
   local ifname
@@ -28,9 +39,9 @@ function net.get_interface(name, family, ula)
         -- check if limklocal fe80::xx:xx:xx:xx addr
         if string.find(interface.addr,'fe') ~= 1 then
           -- check if ula fd52:xx:xx::1 addr
-          if not ula and string.find(interface.addr,'fd') ~= 1 then
+          if not ip_ula and string.find(interface.addr,'fd') ~= 1 then
             return interface
-          elseif ula then
+          elseif ip_ula then
             return interface
           end
         end

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -17,6 +17,10 @@ function net.get_interface(name, family)
   end
   -- get list of interfaces and loop until found
   local interfaces = nixio.getifaddrs()
+  -- sort list of interfaces by addr (2001:xx:xx:xx::1,fd52:xx:xx::1,fe80::xx:xx:xx:901a)
+  table.sort(interfaces, function (left, right)
+    return left['addr'] < right['addr']
+  end)
   for _, interface in pairs(interfaces) do
     if interface.name == ifname and interface.family == ip_family then
       return interface

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -15,16 +15,19 @@ function net.get_interface(name, family, ula)
     -- default to supplied name if none is found
     ifname = uci_cursor:get('network', name, 'ifname') or name
   end
-  -- get list of interfaces and loop until found
+  -- get list of interfaces
   local interfaces = nixio.getifaddrs()
   -- sort list of interfaces by addr (2001:xx:xx:xx::1,fd52:xx:xx::1,fe80::xx:xx:xx:901a)
   table.sort(interfaces, function (left, right)
     return left['addr'] < right['addr']
   end)
+  -- loop until found
   for _, interface in pairs(interfaces) do
     if interface.name == ifname and interface.family == ip_family then
       if ip_family == 'inet6' then
+        -- check if limklocal fe80::xx:xx:xx:xx addr
         if string.find(interface.addr,'fe') ~= 1 then
+          -- check if ula fd52:xx:xx::1 addr
           if not ula and string.find(interface.addr,'fd') ~= 1 then
             return interface
           elseif ula then

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -24,8 +24,8 @@ function net.get_interface(name, family, ula)
   for _, interface in pairs(interfaces) do
     if interface.name == ifname and interface.family == ip_family then
       if ip_family == 'inet6' then
-        if not string.match(interface.addr,'fe',0) then
-          if not ula and not string.match(interface.addr,'fd',0) then
+        if string.find(interface.addr,'fe') ~= 1 then
+          if not ula and string.find(interface.addr,'fd') ~= 1 then
             return interface
           elseif ula then
             return interface

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -5,10 +5,10 @@ local net = {}
 function net.get_interface(name, family, ula)
   local uci_cursor = uci.cursor()
   local ip_family
-  if family == 'inet' then
-    ip_family = 'inet'
-  else
+  if family == 'inet6' then
     ip_family = 'inet6'
+  else
+    ip_family = 'inet'
   end
   local ip_ula
   if ula == '1' then

--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -101,6 +101,14 @@ while [ -n "$1" ]; do
 			export MANAGEMENT_INTERFACE="$2"
 			shift
 			;;
+		--management-interface-family)
+			export MANAGEMENT_INTERFACE_FAMILY="$2"
+			shift
+			;;
+		--management-interface-ula)
+			export MANAGEMENT_INTERFACE_ULA="$2"
+			shift
+			;;
 		--default-hostname)
 			export DEFAULT_HOSTNAME="$2"
 			shift
@@ -245,7 +253,7 @@ fi
 # if management interface is not ready, the ip will be empty but other
 # attempts at determining it will be done before the start-up is completed
 if [ -n "$MANAGEMENT_INTERFACE" ]; then
-	MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE")
+	MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE" "$MANAGEMENT_INTERFACE_FAMILY" "$MANAGEMENT_INTERFACE_ULA")
 fi
 
 get_model() { cat /tmp/sysinfo/model; }
@@ -870,7 +878,7 @@ discover_management_ip() {
 		unset REGISTER_CALLED
 		return
 	fi
-	MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE")
+	MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE" "$MANAGEMENT_INTERFACE_FAMILY" "$MANAGEMENT_INTERFACE_ULA")
 	# if management interface is defined but its ip could not be determined
 	# and the shared secret is not present anymore
 	# (which means the device has been already registered)
@@ -878,7 +886,7 @@ discover_management_ip() {
 	if [ -z "$MANAGEMENT_IP" ] && [ -z "$SHARED_SECRET" ]; then
 		MAX_ATTEMPTS=3
 		for attempt in $(seq $MAX_ATTEMPTS); do
-			MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE")
+			MANAGEMENT_IP=$(/usr/sbin/openwisp-get-address "$MANAGEMENT_INTERFACE" "$MANAGEMENT_INTERFACE_FAMILY" "$MANAGEMENT_INTERFACE_ULA")
 
 			if [ -z "$MANAGEMENT_IP" ]; then
 				logger -s "management interface not ready (attempt $attempt of $MAX_ATTEMPTS)" \

--- a/openwisp-config/files/openwisp.config
+++ b/openwisp-config/files/openwisp.config
@@ -11,6 +11,10 @@ config controller 'http'
 	#option consistent_key '1'
 	#option mac_interface 'eth0'
 	#option management_interface 'tun0'
+	# for IPv4 backward compatibility use "inet". default prio is "inet6" then "inet"
+	#option management_interface_family 'inet'
+	# report IPv6 ula addr. default is 0
+	#option management_interface_ula '1'
 	#option merge_config '1'
 	#option tags ''
 	#option test_config '1'

--- a/openwisp-config/files/openwisp.config
+++ b/openwisp-config/files/openwisp.config
@@ -11,8 +11,9 @@ config controller 'http'
 	#option consistent_key '1'
 	#option mac_interface 'eth0'
 	#option management_interface 'tun0'
-	# for IPv4 backward compatibility use "inet". default prio is "inet6" then "inet"
-	#option management_interface_family 'inet'
+	# for IPv4 backward compatibility use "inet" or leave it blank. default prio is "inet" then "inet6"
+	# new installation starts with ipv6 as default by config. Year's later we can switch to inet6 by default :-)
+	option management_interface_family 'inet6'
 	# report IPv6 ula addr. default is 0
 	#option management_interface_ula '1'
 	#option merge_config '1'

--- a/openwisp-config/files/openwisp.init
+++ b/openwisp-config/files/openwisp.init
@@ -45,6 +45,8 @@ parse_config() {
 	add_option "$cfg" "--cacert" cacert
 	add_option "$cfg" "--mac-interface" mac_interface
 	add_option "$cfg" "--management-interface" management_interface
+	add_option "$cfg" "--management-interface-family" management_interface_family
+	add_option "$cfg" "--management-interface-ula" management_interface_ula
 	add_option "$cfg" "--default-hostname" default_hostname
 	add_option "$cfg" "--pre-reload-hook" pre_reload_hook
 	add_option "$cfg" "--post-reload-hook" post_reload_hook

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -11,7 +11,7 @@ local family = arg[2]
 local ula = arg[3]
 local interface = net.get_interface(name, family, ula)
 if not interface and not family then
-  interface = net.get_interface(name, 'inet')
+  interface = net.get_interface(name, 'inet6')
 end
 
 if interface then

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -7,9 +7,9 @@
 local os = require('os')
 local net = require('openwisp.net')
 local name = arg[1]
-local interface = net.get_interface(name, 'inet')
+local interface = net.get_interface(name)
 if not interface then
-  interface = net.get_interface(name, 'inet6')
+  interface = net.get_interface(name, 'inet')
 end
 
 if interface then

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -2,13 +2,15 @@
 
 -- gets the first useful address of the specified interface
 -- usage:
---   * openwisp-get-address <ifname>
---   * openwisp-get-address <network-name>
+--   * openwisp-get-address <ifname> ["inet"|"inet6"] [ula 1|0]
+--   * openwisp-get-address <network-name> ["inet"|"inet6"] [ula 1|0]
 local os = require('os')
 local net = require('openwisp.net')
 local name = arg[1]
-local interface = net.get_interface(name)
-if not interface then
+local family = arg[2]
+local ula = arg[3]
+local interface = net.get_interface(name, family, ula)
+if not interface and not family then
   interface = net.get_interface(name, 'inet')
 end
 

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -10,7 +10,7 @@ local name = arg[1]
 local family = arg[2]
 local ula = arg[3]
 local interface = net.get_interface(name, family, ula)
-if not interface and not family then
+if not interface and family ~= 'inet6' then
   interface = net.get_interface(name, 'inet6')
 end
 


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes
Added uci option management_interface_family 'inet6'
Prefer ipv6 on new installations.
for IPv4 backward compatibility use "inet" or leave it blank. default prio is "inet" then "inet6"
For IPv4 only use "inet".
Added uci option management_interface_ula
If it set and there is no Public ipv6 than report ula address.

Please review it could broke backward compatibility
 