### PR TITLE
[refactor] Move Logging from `init.d` to Agent

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -129,6 +129,10 @@ while [ -n "$1" ]; do
 			export CHECKSUM_RETRY_DELAY="$2"
 			shift
 			;;
+		--log-message)
+			log_message "$2"
+			exit 0
+			;;
 		-*)
 			echo "Invalid option: $1"
 			exit 1
@@ -971,3 +975,10 @@ while true; do
 	# ignore SIGUSR1 signals again
 	trap "" USR1
 done
+
+# Logging function
+log_message() {
+	local level="$1"
+	local message="$2"
+	os.execute(string.format('logger -t openwisp -p %s "%s"', level, message))
+}

--- a/openwisp-config/files/openwisp.init
+++ b/openwisp-config/files/openwisp.init
@@ -75,7 +75,7 @@ start_service() {
 	config_foreach parse_config controller
 	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_close_instance
-	logger -s "$PROG_NAME started" -t openwisp -p daemon.info
+	/usr/sbin/openwisp-config --log-message "$PROG_NAME started"
 }
 
 service_triggers() {
@@ -87,7 +87,7 @@ stop_service() {
 }
 
 reload_service() {
-	logger -s "$PROG_NAME received reload trigger" -t openwisp -p daemon.info
+	/usr/sbin/openwisp-config --log-message "$PROG_NAME received reload trigger"
 	# avoid reloading while configuration is being applied
 	# will wait for a maximum of 30 seconds
 	for _ in $(seq 1 30); do

--- a/openwisp-config/files/sbin/openwisp-reload-config
+++ b/openwisp-config/files/sbin/openwisp-reload-config
@@ -22,7 +22,8 @@ if [ -f $MD5FILE ]; then
 			logger_msg="Service $service has been reloaded via init.d script"
 		fi
 		# log which service has been reloaded and how
-		logger "$logger_msg" -t openwisp -p daemon.info
+		/usr/sbin/openwisp-config --log-message "$logger_msg"
+		
 	done
 fi
 md5sum /var/run/config.check/* >$MD5FILE


### PR DESCRIPTION
## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

#### **Description:**
This PR refactors the logging mechanism in the OpenWISP configuration system to centralize logging in the agent (`openwisp.agent`) instead of directly using the `logger` command in `init.d` scripts.

#### **Changes:**
1. **Removed Direct `logger` Calls:**
   - Removed `logger` calls from `openwisp-reload-config` and `openwisp.init`.

2. **Added Logging to Agent:**
   - Added a `log_message` function in `openwisp.agent` to handle logging.
   - Implemented support for the `--log-message` argument in the agent to log messages.

3. **Updated Scripts:**
   - Updated `openwisp-reload-config` to call the agent for logging via `/usr/sbin/openwisp-config --log-message`.


#### **Testing:**
- Verified that log messages are correctly generated by the agent when:
  - Running `/usr/sbin/openwisp-reload-config`.
  - Using the `--log-message` argument with `/usr/sbin/openwisp-config`.
  - Restarting the OpenWISP service.

#### **Fixes:**
- Resolves #145 