### PR TITLE
[fix] delay stop until configuration is applied

### DIFF
--- a/openwisp-config/files/openwisp.init
+++ b/openwisp-config/files/openwisp.init
@@ -82,21 +82,27 @@ service_triggers() {
 	procd_add_reload_trigger openwisp
 }
 
-stop_service() {
-	logger -s "$PROG_NAME stopping" -t openwisp -p daemon.info
-}
-
-reload_service() {
-	logger -s "$PROG_NAME received reload trigger" -t openwisp -p daemon.info
-	# avoid reloading while configuration is being applied
+wait_applying_config() {
+	# avoid stopping/reloading while configuration is being applied
 	# will wait for a maximum of 30 seconds
 	for _ in $(seq 1 30); do
 		if [ -f "$CONTROL_FILE" ]; then
 			sleep 1
 		else
-			break
+			return 0
 		fi
 	done
+	# timed out: remove stale marker so we can proceed
 	rm -f "$CONTROL_FILE"
+}
+
+stop_service() {
+	logger -s "$PROG_NAME stopping" -t openwisp -p daemon.info
+	wait_applying_config
+}
+
+reload_service() {
+	logger -s "$PROG_NAME received reload trigger" -t openwisp -p daemon.info
+	wait_applying_config
 	start
 }


### PR DESCRIPTION
## Reference to Existing Issue

Closes #172.

## Description of Changes

In some cases, the agent may be stopped while a configuration is being applied, leaving the device in an inconsistent state (configuration partially applied, or status not reported back to the OpenWISP server).

The [reload_service](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:102:0-106:1) function already had a mechanism to delay reloading while `CONTROL_FILE` (`/tmp/openwisp/applying_conf`) exists. This PR extends the same protection to [stop_service](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:97:0-100:1) by:

1. Extracting the 30-second wait loop from [reload_service](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:102:0-106:1) into a reusable helper function [wait_applying_config()](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:84:0-95:1).
2. Calling [wait_applying_config()](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:84:0-95:1) from both [reload_service](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:102:0-106:1) and [stop_service](cci:1://file:///home/viscous/Viscous/gsoc/openwisp-config.git/issues/172-bugFix/openwisp-config/files/openwisp.init:97:0-100:1).

This ensures the agent will not be abruptly terminated mid-configuration, regardless of what triggers the stop (system reboot, package upgrade, watchdog script, etc.).

## Screenshot

<img width="1524" height="742" alt="image" src="https://github.com/user-attachments/assets/e924b083-98cc-451e-a6ea-1c8ec0488882" />
