### PR TITLE
[fix] Added support for PPPoE management interfaces

### DIFF
--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -7,9 +7,12 @@ function net.get_interface(name, family)
   local ip_family = family or 'inet'
   -- if UCI network name is a bridge, the ifname won't be the name of the bridge
   local is_bridge = uci_cursor:get('network', name, 'type') == 'bridge'
+  local is_pppoe = uci_cursor:get('network', name, 'proto') == 'pppoe'
   local ifname
   if is_bridge then
     ifname = 'br-' .. name
+  elseif is_pppoe then
+    ifname = 'pppoe-' .. name
   else
     -- get ifname from network configuration or
     -- default to supplied name if none is found

--- a/openwisp-config/tests/test_net.lua
+++ b/openwisp-config/tests/test_net.lua
@@ -1,0 +1,48 @@
+-- manually add lib dir to lua package path
+package.path = package.path .. ';../files/lib/?.lua'
+
+local luaunit = require('luaunit')
+local network_config = {}
+local interfaces = {}
+
+package.loaded['uci'] = {
+  cursor = function()
+    return {
+      get = function(_, config, section, option)
+        if config ~= 'network' or not network_config[section] then
+          return nil
+        end
+        return network_config[section][option]
+      end
+    }
+  end
+}
+
+package.loaded['nixio'] = {getifaddrs = function() return interfaces end}
+local net = require('openwisp.net')
+TestNet = {}
+
+function TestNet.setUp()
+  network_config = {}
+  interfaces = {}
+end
+
+function TestNet.test_get_interface_uses_bridge_prefix()
+  network_config.lan = {type = 'bridge'}
+  interfaces = {{name = 'br-lan', family = 'inet', addr = '192.168.1.1'}}
+  local interface = net.get_interface('lan')
+  luaunit.assertNotNil(interface)
+  luaunit.assertEquals(interface.name, 'br-lan')
+  luaunit.assertEquals(interface.addr, '192.168.1.1')
+end
+
+function TestNet.test_get_interface_uses_pppoe_prefix()
+  network_config.wan = {proto = 'pppoe'}
+  interfaces = {{name = 'pppoe-wan', family = 'inet', addr = '192.0.2.1'}}
+  local interface = net.get_interface('wan')
+  luaunit.assertNotNil(interface)
+  luaunit.assertEquals(interface.name, 'pppoe-wan')
+  luaunit.assertEquals(interface.addr, '192.0.2.1')
+end
+
+os.exit(luaunit.LuaUnit.run())

--- a/runtests
+++ b/runtests
@@ -9,5 +9,6 @@ lua test_uci_autoname.lua -v
 lua test_update_bad_config.lua -v
 lua test_update_bug_missing_file.lua -v
 lua test_update_config.lua -v
+lua test_net.lua -v
 lua test_utils.lua -v
 lua test_random_number.lua -v


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #258

## Description of Changes

The interface protocol is checked for it being `pppoe`  if true since openwrt names the actual interface returned by nixio to pppoe-xxx , `pppoe-` is prepended like done for the bridge case


