### PR TITLE
[fix] Retry registration on transient controller 5xx errors

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -348,6 +348,17 @@ register() {
 			-p daemon.err
 		return 1
 	fi
+	# A transient server-side error (HTTP 5xx, e.g. 502/503/504 from a reverse
+	# proxy while the backend is restarting) carries no X-Openwisp-Controller
+	# header. Without this guard check_header below would treat it as a wrong
+	# server and call `exit 4`, killing the agent for good once procd's respawn
+	# limit is exhausted. Treat 5xx as a temporary failure and retry instead.
+	if head -n 1 "$REGISTRATION_PARAMETERS" | tr -d '\r' | grep -qE "^HTTP/[0-9.]+ 5[0-9][0-9]( |$)"; then
+		logger -s "Registration temporarily failed (controller returned 5xx), will retry: $(head -n 1 "$REGISTRATION_PARAMETERS" | tr -d '\r')" \
+			-t openwisp \
+			-p daemon.warning
+		return 2
+	fi
 	# exit if response does not seem to come from openwisp controller
 	check_header $REGISTRATION_PARAMETERS
 	if ! is_http_status $REGISTRATION_PARAMETERS 201; then


### PR DESCRIPTION
## Problem

During device registration the agent calls `check_header()` **before** checking
the HTTP status code. A transient server-side error (HTTP 5xx — e.g. `502`/`503`/
`504` returned by a reverse proxy while the backend is restarting) carries no
`X-Openwisp-Controller` header, so `check_header` treats the response as coming
from the *wrong server* and calls `exit 4`.

Combined with procd's respawn limit (`respawn ... 5`), a short controller outage
that happens to overlap a (re)registration attempt makes procd give up
permanently after a few exits — leaving the agent **dead until a manual
restart**, even though the controller recovered seconds later.

The other three `check_header` call sites (`get_checksum`, `update_info`, status
report) already guard with an `is_http_status ... 200` check before calling
`check_header`, so a 5xx there returns a retryable code. Only the registration
path was missing this guard.

## Fix

Treat a 5xx registration response as a temporary failure (`return 2`, retryable)
**before** `check_header` runs. Non-5xx responses still go through `check_header`,
preserving the existing "wrong server" safety (`exit 4`) for a 2xx response that
lacks the controller header.

```sh
if head -n 1 "$REGISTRATION_PARAMETERS" | grep -qE " 5[0-9][0-9] "; then
    logger -s "Registration temporarily failed (controller returned 5xx), will retry: ..." \
        -t openwisp -p daemon.warning
    return 2
fi
```

The `curl -i` output that populates `$REGISTRATION_PARAMETERS` starts with the
status line (e.g. `HTTP/1.1 502 Bad Gateway`), so the ` 5[0-9][0-9] ` match is
consistent with how `is_http_status` reads the status elsewhere.

## Testing

- `shellcheck -s sh` on `openwisp.agent`: clean.
- `shfmt` format check: clean.
- Focused behavioural check of the new branch against mocked `curl -i` status
  lines: `502`/`503`/`504` → retry (`return 2`); `200`/`201`/`403`/`404` → fall
  through to `check_header` unchanged.

This is a small, self-contained change to the registration retry logic; the
existing non-5xx behaviour is preserved.
