### PR TITLE
[fix] Remove backup file list temp files after backup

### DIFF
--- a/openwisp-config/files/openwisp.agent
+++ b/openwisp-config/files/openwisp.agent
@@ -857,7 +857,7 @@ backup_configuration() {
 	sort -u "${BACKUP_FILE_LIST}.tmp" >$BACKUP_FILE_LIST
 	# backup only those files
 	tar -zcf $CONFIGURATION_BACKUP -T $BACKUP_FILE_LIST
-	rm "${BACKUP_FILE_LIST}*"
+	rm -f "${BACKUP_FILE_LIST}.tmp" "$BACKUP_FILE_LIST"
 }
 
 restore_backup() {


### PR DESCRIPTION
## Problem

The cleanup at the end of `backup_configuration()` uses a glob **inside** double
quotes:

```sh
rm "${BACKUP_FILE_LIST}*"
```

The shell does not expand the `*` inside quotes, so `rm` tries to delete a
single file literally named `backup_file_list.conf*`, which never exists. This
fails on every configuration update (`rm: can't remove
'.../backup_file_list.conf*'`) and leaves `backup_file_list.conf` and
`backup_file_list.conf.tmp` behind in the working directory (tmpfs on devices).

## Fix

Delete the two files that are actually created, with `-f` so a missing file is
not an error.

## Testing

`shellcheck`, `shfmt`, `./run-qa-checks` and `./runtests` all pass.
