### PR TITLE
[fix] Skipped invalid file paths before applying config #265

### DIFF
--- a/openwisp-config/files/lib/openwisp/utils.lua
+++ b/openwisp-config/files/lib/openwisp/utils.lua
@@ -160,6 +160,18 @@ end
 
 function utils.starts_with(str, start) return str:sub(1, #start) == start end
 
+function utils.is_valid_file_path(path)
+  if type(path) ~= 'string' or path == '' then return false end
+  if string.find(path, '[^%w%._/%-]') then return false end
+  if string.find(path, '//') or string.sub(path, -1) == '/' then return false end
+  local relative_path = string.gsub(path, '^/', '')
+  if relative_path == '' then return false end
+  for component in string.gmatch(relative_path, '[^/]+') do
+    if component == '.' or component == '..' then return false end
+  end
+  return true
+end
+
 -- iterates over a table in alphabeticaly order
 function utils.sorted_pairs(t)
   -- collect keys

--- a/openwisp-config/files/lib/openwisp/utils.lua
+++ b/openwisp-config/files/lib/openwisp/utils.lua
@@ -160,6 +160,7 @@ end
 
 function utils.starts_with(str, start) return str:sub(1, #start) == start end
 
+-- Extra files come from downloaded archives; keep accepted paths simple.
 function utils.is_valid_file_path(path)
   if type(path) ~= 'string' or path == '' then return false end
   if string.find(path, '[^%w%._/%-]') then return false end
@@ -170,6 +171,11 @@ function utils.is_valid_file_path(path)
     if component == '.' or component == '..' then return false end
   end
   return true
+end
+
+-- Escape paths passed to os.execute so the shell does not interpret them.
+function utils.escape_shell_arg(value)
+  return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
 end
 
 -- iterates over a table in alphabeticaly order

--- a/openwisp-config/files/sbin/openwisp-update-config.lua
+++ b/openwisp-config/files/sbin/openwisp-update-config.lua
@@ -208,8 +208,9 @@ for path, attr in utils.dirtree(remote_dir) do
           modified[dest_path] = true
           modified_changed = true
           -- store original in /etc/openwisp/stored/<path>
-          os.execute('mkdir -p ' .. stored_dir .. dest_dir)
-          os.execute('cp ' .. check_path .. ' ' .. stored_dir .. dest_path)
+          os.execute('mkdir -p ' .. utils.escape_shell_arg(stored_dir .. dest_dir))
+          os.execute('cp ' .. utils.escape_shell_arg(check_path) .. ' ' ..
+                       utils.escape_shell_arg(stored_dir .. dest_path))
         else
           -- add file path added set
           added[dest_path] = true
@@ -221,8 +222,9 @@ for path, attr in utils.dirtree(remote_dir) do
         dest_dir = test_root_dir .. dest_dir
       end
       -- add file to filesystem
-      os.execute('mkdir -p ' .. dest_dir)
-      os.execute('cp ' .. path .. ' ' .. dest_path)
+      os.execute('mkdir -p ' .. utils.escape_shell_arg(dest_dir))
+      os.execute('cp ' .. utils.escape_shell_arg(path) .. ' ' ..
+                   utils.escape_shell_arg(dest_path))
     end
   end
 end

--- a/openwisp-config/files/sbin/openwisp-update-config.lua
+++ b/openwisp-config/files/sbin/openwisp-update-config.lua
@@ -192,34 +192,38 @@ for path, attr in utils.dirtree(remote_dir) do
   if attr.mode == 'file' and not is_ignored(path) then
     -- calculates destination dir
     local dest_path = path:sub(#(remote_dir .. '/'))
-    local dest_dir = utils.dirname(dest_path)
-    -- like dest_path but used during automated tests
-    local check_path = not TEST and dest_path or test_root_dir .. dest_path
-    local is_added = added[dest_path] == true
-    local is_modified = modified[dest_path] == true
-    -- if file is neither in added.list nor modified.list
-    if is_added == false and is_modified == false then
-      -- if file exists
-      if utils.file_exists(check_path) then
-        -- add file path to modified set
-        modified[dest_path] = true
-        modified_changed = true
-        -- store original in /etc/openwisp/stored/<path>
-        os.execute('mkdir -p ' .. stored_dir .. dest_dir)
-        os.execute('cp ' .. check_path .. ' ' .. stored_dir .. dest_path)
-      else
-        -- add file path added set
-        added[dest_path] = true
-        added_changed = true
+    if not utils.is_valid_file_path(dest_path) then
+      print('WARNING: skipping invalid file path: ' .. dest_path)
+    else
+      local dest_dir = utils.dirname(dest_path)
+      -- like dest_path but used during automated tests
+      local check_path = not TEST and dest_path or test_root_dir .. dest_path
+      local is_added = added[dest_path] == true
+      local is_modified = modified[dest_path] == true
+      -- if file is neither in added.list nor modified.list
+      if is_added == false and is_modified == false then
+        -- if file exists
+        if utils.file_exists(check_path) then
+          -- add file path to modified set
+          modified[dest_path] = true
+          modified_changed = true
+          -- store original in /etc/openwisp/stored/<path>
+          os.execute('mkdir -p ' .. stored_dir .. dest_dir)
+          os.execute('cp ' .. check_path .. ' ' .. stored_dir .. dest_path)
+        else
+          -- add file path added set
+          added[dest_path] = true
+          added_changed = true
+        end
       end
+      if TEST then
+        dest_path = test_root_dir .. dest_path
+        dest_dir = test_root_dir .. dest_dir
+      end
+      -- add file to filesystem
+      os.execute('mkdir -p ' .. dest_dir)
+      os.execute('cp ' .. path .. ' ' .. dest_path)
     end
-    if TEST then
-      dest_path = test_root_dir .. dest_path
-      dest_dir = test_root_dir .. dest_dir
-    end
-    -- add file to filesystem
-    os.execute('mkdir -p ' .. dest_dir)
-    os.execute('cp ' .. path .. ' ' .. dest_path)
   end
 end
 

--- a/openwisp-config/tests/test_update_config.lua
+++ b/openwisp-config/tests/test_update_config.lua
@@ -46,6 +46,8 @@ TestUpdateConfig = {
     tearDown = function()
         os.execute('rm -rf ' .. write_dir)
         os.execute('rm -rf ' .. openwisp_dir)
+        os.execute('rm -rf invalid-conf')
+        os.execute('rm -f invalid-conf.tar.gz pwned')
         os.execute('rm configuration.tar.gz')
     end
 }
@@ -213,6 +215,16 @@ function TestUpdateConfig.test_removal_list_options()
     luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
     luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
     luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
+end
+
+function TestUpdateConfig.test_invalid_extra_file_path_is_skipped()
+    os.execute('mkdir -p invalid-conf')
+    os.execute('tar -zxf good-config.tar.gz -C invalid-conf')
+    os.execute('touch "invalid-conf/etc/x; touch pwned ;"')
+    os.execute('tar -czf invalid-conf.tar.gz -C invalid-conf etc')
+    update_config('--test=1', '--conf=./invalid-conf.tar.gz')
+    luaunit.assertNil(io.open('pwned'))
+    luaunit.assertNil(io.open(write_dir .. 'etc/x; touch pwned ;'))
 end
 
 os.exit(luaunit.LuaUnit.run())

--- a/openwisp-config/tests/test_update_config.lua
+++ b/openwisp-config/tests/test_update_config.lua
@@ -220,6 +220,7 @@ end
 function TestUpdateConfig.test_invalid_extra_file_path_is_skipped()
     os.execute('mkdir -p invalid-conf')
     os.execute('tar -zxf good-config.tar.gz -C invalid-conf')
+    -- Semicolons would be interpreted by the shell if this path was used raw.
     os.execute('touch "invalid-conf/etc/x; touch pwned ;"')
     os.execute('tar -czf invalid-conf.tar.gz -C invalid-conf etc')
     update_config('--test=1', '--conf=./invalid-conf.tar.gz')

--- a/openwisp-config/tests/test_utils.lua
+++ b/openwisp-config/tests/test_utils.lua
@@ -30,6 +30,12 @@ function TestUtils.test_is_valid_file_path()
   luaunit.assertEquals(utils.is_valid_file_path('{{cert_path}}'), false)
 end
 
+function TestUtils.test_escape_shell_arg()
+  luaunit.assertEquals(utils.escape_shell_arg('/etc/config/network'),
+    "'/etc/config/network'")
+  luaunit.assertEquals(utils.escape_shell_arg("a'b"), "'a'\\''b'")
+end
+
 function TestUtils.test_write_uci_section_named()
   local u = uci.cursor(write_dir)
   utils.write_uci_section(u, 'network', {

--- a/openwisp-config/tests/test_utils.lua
+++ b/openwisp-config/tests/test_utils.lua
@@ -21,6 +21,15 @@ function TestUtils.test_starts_with_dot()
   luaunit.assertEquals(utils.starts_with_dot('ifname'), false)
 end
 
+function TestUtils.test_is_valid_file_path()
+  luaunit.assertEquals(utils.is_valid_file_path('/etc/config/network'), true)
+  luaunit.assertEquals(utils.is_valid_file_path('etc/openvpn/client.conf'), true)
+  luaunit.assertEquals(utils.is_valid_file_path('tmp/x; reboot'), false)
+  luaunit.assertEquals(utils.is_valid_file_path('../../../etc/passwd'), false)
+  luaunit.assertEquals(utils.is_valid_file_path('tmp/a b'), false)
+  luaunit.assertEquals(utils.is_valid_file_path('{{cert_path}}'), false)
+end
+
 function TestUtils.test_write_uci_section_named()
   local u = uci.cursor(write_dir)
   utils.write_uci_section(u, 'network', {


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #265.

Related root validation change: openwisp/netjsonconfig#400.

## Description of Changes

This change makes `openwisp-update-config.lua` skip invalid extra file paths
found in downloaded configuration archives.

The main validation is handled in `netjsonconfig`, but the agent should still
be defensive when applying archives generated by older controllers or other
sources. Invalid paths are logged and skipped before any file operation is
attempted.

The accepted path format is intentionally small: normal absolute or relative
paths with letters, numbers, dots, underscores, dashes and slashes. Paths with
shell characters, whitespace, braces, empty path parts, `.` or `..` components
are rejected.

## Screenshot

Not applicable.
