### PR TITLE
[change] Added support for removing the default 6GHz SSID in is_default_wifi lua function

### DIFF
--- a/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
+++ b/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
@@ -16,11 +16,12 @@ local standard_path = standard_prefix .. 'config/'
 -- standard standard
 local standard = uci.cursor(standard_path)
 local changed = false
+local default_encryption = {none = true, owe = true}
+local default_ssid = {LEDE = true, OpenWrt = true}
 
 local function is_default_wifi(section)
-  if (section.encryption == "none" or section.encryption == "owe")
-    and section.mode == 'ap' and section.network ==
-    'lan' and (section.ssid == 'LEDE' or section.ssid == 'OpenWrt') then return true end
+  if default_encryption[section.encryption] and section.mode == 'ap' and
+    section.network == 'lan' and default_ssid[section.ssid] then return true end
   return false
 end
 

--- a/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
+++ b/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
@@ -18,7 +18,8 @@ local standard = uci.cursor(standard_path)
 local changed = false
 
 local function is_default_wifi(section)
-  if section.encryption == 'none' and section.mode == 'ap' and section.network ==
+  if (section.encryption == "none" or section.encryption == "owe")
+    and section.mode == 'ap' and section.network ==
     'lan' and (section.ssid == 'LEDE' or section.ssid == 'OpenWrt') then return true end
   return false
 end

--- a/openwisp-config/tests/wifi/wireless
+++ b/openwisp-config/tests/wifi/wireless
@@ -48,3 +48,11 @@ config wifi-iface
 	option device 'radio1'
 	option mode 'ap'
 	option network 'lan'
+
+config wifi-iface
+	option ssid 'OpenWrt'
+	option encryption 'owe'
+	option device 'radio2'
+	option mode 'ap'
+	option network 'lan'
+	option ieee80211w '2'


### PR DESCRIPTION
On a 6Ghz radio "open" is not allowed, so OpenWrt defaults to "owe".

## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-config/issues/new/choose) if there isn't an existing issue yet. -->

Closes #272 

## Description of Changes

Removes the 6GHz default uci entry wifi created by openwrt

e.g.

```
config wifi-iface 'default_radio1'
	option device 'radio1'
	option network 'lan'
	option mode 'ap'
	option ssid 'OpenWrt'
	option encryption 'owe'
	option disabled '1'
```

## Screenshot

Not applicable
