### PR TITLE
[qa] Aligned formatting checks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,5 @@
 ignore = {"213/_.*"} -- unused Loop Variables beginning with underscore
+max_line_length = 110
 files["openwisp-config/tests"] = {
     ignore = {"11./Test.*"} -- globals relating to defining unittests
 }

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -26,10 +26,19 @@ luarocks install luaunit
 # install luacheck
 luarocks install luacheck
 # install luaformatter
-git clone --recurse-submodules https://github.com/Koihik/LuaFormatter.git LuaFormatter && (
-	cd LuaFormatter \
-		&& cmake -DBUILD_TESTS=OFF . \
-		&& make install
-) || { rm -rf LuaFormatter && echo 'Installing LuaFormatter failed' && exit 1; }
+if ! git clone --recurse-submodules https://github.com/Koihik/LuaFormatter.git LuaFormatter; then
+	rm -rf LuaFormatter
+	echo 'Installing LuaFormatter failed'
+	exit 1
+fi
+if ! (
+	cd LuaFormatter
+	cmake -DBUILD_TESTS=OFF .
+	make install
+); then
+	rm -rf LuaFormatter
+	echo 'Installing LuaFormatter failed'
+	exit 1
+fi
 # clean
 rm -rf json-c libubox uci LuaFormatter

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -26,12 +26,8 @@ luarocks install luaunit
 # install luacheck
 luarocks install luacheck
 # install luaformatter
-# Pin LuaFormatter and its submodules to immutable commits before building.
-LUA_FORMATTER_COMMIT=417d4570a4265109ebbab6610023e91c4668f631
-git clone --no-checkout https://github.com/Koihik/LuaFormatter.git LuaFormatter && (
+git clone --recurse-submodules https://github.com/Koihik/LuaFormatter.git LuaFormatter && (
 	cd LuaFormatter \
-		&& git checkout --detach "$LUA_FORMATTER_COMMIT" \
-		&& git submodule update --init --recursive \
 		&& cmake -DBUILD_TESTS=OFF . \
 		&& make install
 ) || { rm -rf LuaFormatter && echo 'Installing LuaFormatter failed' && exit 1; }

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -25,5 +25,8 @@ luarocks install luafilesystem
 luarocks install luaunit
 # install luacheck
 luarocks install luacheck
+# install luaformatter
+git clone --recurse-submodules https://github.com/Koihik/LuaFormatter.git
+{ cd LuaFormatter && cmake . && make install && cd ..; } || { echo 'Installing LuaFormatter failed' && exit 1; }
 # clean
-rm -rf json-c libubox uci
+rm -rf json-c libubox uci LuaFormatter

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -26,7 +26,14 @@ luarocks install luaunit
 # install luacheck
 luarocks install luacheck
 # install luaformatter
-git clone --recurse-submodules https://github.com/Koihik/LuaFormatter.git
-{ cd LuaFormatter && cmake . && make install && cd ..; } || { echo 'Installing LuaFormatter failed' && exit 1; }
+# Pin LuaFormatter and its submodules to immutable commits before building.
+LUA_FORMATTER_COMMIT=417d4570a4265109ebbab6610023e91c4668f631
+git clone --no-checkout https://github.com/Koihik/LuaFormatter.git LuaFormatter && (
+	cd LuaFormatter \
+		&& git checkout --detach "$LUA_FORMATTER_COMMIT" \
+		&& git submodule update --init --recursive \
+		&& cmake . \
+		&& make install
+) || { rm -rf LuaFormatter && echo 'Installing LuaFormatter failed' && exit 1; }
 # clean
 rm -rf json-c libubox uci LuaFormatter

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -32,7 +32,7 @@ git clone --no-checkout https://github.com/Koihik/LuaFormatter.git LuaFormatter 
 	cd LuaFormatter \
 		&& git checkout --detach "$LUA_FORMATTER_COMMIT" \
 		&& git submodule update --init --recursive \
-		&& cmake . \
+		&& cmake -DBUILD_TESTS=OFF . \
 		&& make install
 ) || { rm -rf LuaFormatter && echo 'Installing LuaFormatter failed' && exit 1; }
 # clean

--- a/openwisp-config/files/lib/openwisp/net.lua
+++ b/openwisp-config/files/lib/openwisp/net.lua
@@ -21,9 +21,7 @@ function net.get_interface(name, family)
   -- get list of interfaces and loop until found
   local interfaces = nixio.getifaddrs()
   for _, interface in pairs(interfaces) do
-    if interface.name == ifname and interface.family == ip_family then
-      return interface
-    end
+    if interface.name == ifname and interface.family == ip_family then return interface end
   end
   -- return nil if nothing is found
   return nil

--- a/openwisp-config/files/lib/openwisp/utils.lua
+++ b/openwisp-config/files/lib/openwisp/utils.lua
@@ -91,7 +91,7 @@ end
 
 -- returns true if uci section is empty
 function utils.is_uci_empty(table)
-  for key, value in pairs(table) do if not utils.starts_with_dot(key) then return false end end
+  for key in pairs(table) do if not utils.starts_with_dot(key) then return false end end
   return true
 end
 

--- a/openwisp-config/files/lib/openwisp/utils.lua
+++ b/openwisp-config/files/lib/openwisp/utils.lua
@@ -4,7 +4,9 @@ local lfs = require('lfs')
 
 local utils = {}
 
-function utils.starts_with_dot(str) return str:sub(1, 1) == '.' end
+function utils.starts_with_dot(str)
+  return str:sub(1, 1) == '.'
+end
 
 function utils.split(input, sep)
   if input == '' or input == nil then return {} end
@@ -27,9 +29,7 @@ function utils.dirname(path)
   local parts = utils.split(path, '/')
   local returnPath = '/'
   local length = table.getn(parts)
-  for i, part in ipairs(parts) do
-    if i < length then returnPath = returnPath .. part .. '/' end
-  end
+  for i, part in ipairs(parts) do if i < length then returnPath = returnPath .. part .. '/' end end
   return returnPath
 end
 
@@ -91,9 +91,7 @@ end
 
 -- returns true if uci section is empty
 function utils.is_uci_empty(table)
-  for key, value in pairs(table) do
-    if not utils.starts_with_dot(key) then return false end
-  end
+  for key, value in pairs(table) do if not utils.starts_with_dot(key) then return false end end
   return true
 end
 
@@ -132,7 +130,9 @@ function utils.dirtree(dir_param)
       end
     end
   end
-  return coroutine.wrap(function() yieldtree(dir_param) end)
+  return coroutine.wrap(function()
+    yieldtree(dir_param)
+  end)
 end
 
 function utils.file_exists(path)
@@ -158,7 +158,9 @@ function utils.set_to_file(set, path)
   return true
 end
 
-function utils.starts_with(str, start) return str:sub(1, #start) == start end
+function utils.starts_with(str, start)
+  return str:sub(1, #start) == start
+end
 
 -- Extra files come from downloaded archives; keep accepted paths simple.
 function utils.is_valid_file_path(path)

--- a/openwisp-config/files/sbin/openwisp-get-address.lua
+++ b/openwisp-config/files/sbin/openwisp-get-address.lua
@@ -8,9 +8,7 @@ local os = require('os')
 local net = require('openwisp.net')
 local name = arg[1]
 local interface = net.get_interface(name, 'inet')
-if not interface then
-  interface = net.get_interface(name, 'inet6')
-end
+if not interface then interface = net.get_interface(name, 'inet6') end
 
 if interface then
   print(interface.addr)

--- a/openwisp-config/files/sbin/openwisp-get-random-number.lua
+++ b/openwisp-config/files/sbin/openwisp-get-random-number.lua
@@ -13,8 +13,7 @@ for _, value in pairs(arg) do
 end
 
 local function to_int(str)
-  return math.floor(tonumber(str) or
-                      error("Could not cast '" .. tostring(str) .. "' to number.'"))
+  return math.floor(tonumber(str) or error("Could not cast '" .. tostring(str) .. "' to number.'"))
 end
 
 local function get_random(seed, minimum_value, maximum_value)

--- a/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
+++ b/openwisp-config/files/sbin/openwisp-remove-default-wifi.lua
@@ -20,8 +20,8 @@ local default_encryption = {none = true, owe = true}
 local default_ssid = {LEDE = true, OpenWrt = true}
 
 local function is_default_wifi(section)
-  if default_encryption[section.encryption] and section.mode == 'ap' and
-    section.network == 'lan' and default_ssid[section.ssid] then return true end
+  if default_encryption[section.encryption] and section.mode == 'ap' and section.network == 'lan' and
+    default_ssid[section.ssid] then return true end
   return false
 end
 

--- a/openwisp-config/files/sbin/openwisp-store-unmanaged.lua
+++ b/openwisp-config/files/sbin/openwisp-store-unmanaged.lua
@@ -87,9 +87,7 @@ for config_name, config_values in pairs(unmanaged_map) do
     for i, element in pairs(config_values) do
       if element.name then
         local section = uci_table[element.name]
-        if section then
-          utils.write_uci_section(unmanaged, config_name, section, true)
-        end
+        if section then utils.write_uci_section(unmanaged, config_name, section, true) end
       else
         standard:foreach(config_name, element.type, function(section)
           utils.write_uci_section(unmanaged, config_name, section, true)

--- a/openwisp-config/files/sbin/openwisp-uci-autoname.lua
+++ b/openwisp-config/files/sbin/openwisp-uci-autoname.lua
@@ -17,8 +17,8 @@ local standard_prefix = test and '../tests/' or '/etc/'
 local standard_path = standard_prefix .. (test and 'anonymous' or 'config')
 local standard = uci.cursor(standard_path) -- read operations
 
-local output = standard  -- write operations
-local stdout = ''  -- result
+local output = standard -- write operations
+local stdout = '' -- result
 local new_name = ''
 local all_names = {}
 
@@ -51,9 +51,7 @@ for file in lfs.dir(standard_path) do
     local changed = false
     -- avoid name collisions by storing all existing names
     standard:foreach(file, nil, function(section)
-      if not section['.anonymous'] then
-        all_names[section['.name']] = true
-      end
+      if not section['.anonymous'] then all_names[section['.name']] = true end
     end)
     standard:foreach(file, nil, function(section)
       local index = section['.index']
@@ -65,8 +63,7 @@ for file in lfs.dir(standard_path) do
           new_name = 'globals'
         elseif file == 'network' and section['.type'] == 'device' then
           new_name = 'device_' .. section['name']:gsub('br%-', '')
-        elseif file == 'network' and
-          (section['.type'] == 'route' or section['.type'] == 'route6') then
+        elseif file == 'network' and (section['.type'] == 'route' or section['.type'] == 'route6') then
           new_name = nextAvailableName('route')
         elseif file == 'network' and section['.type'] == 'switch' then
           new_name = section['name']
@@ -80,9 +77,7 @@ for file in lfs.dir(standard_path) do
           new_name = 'led_' .. string.lower(section['name'])
         elseif file == 'wireless' and section['.type'] == 'wifi-iface' then
           if section['ifname'] == nil then
-            new_name = 'wifi_' .. (
-              standard:get('network', section['network'], 'ifname')
-            )
+            new_name = 'wifi_' .. (standard:get('network', section['network'], 'ifname'))
           else
             new_name = 'wifi_' .. section['ifname']
           end
@@ -90,9 +85,7 @@ for file in lfs.dir(standard_path) do
           new_name = nextAvailableName(section['.type'])
         end
         -- make sure the new name is unique
-        if all_names[new_name] then
-            new_name = nextAvailableName(new_name .. '_')
-        end
+        if all_names[new_name] then new_name = nextAvailableName(new_name .. '_') end
         all_names[new_name] = true
         -- make sure name is valid
         section['.name'] = getUCIName(new_name)

--- a/openwisp-config/files/sbin/openwisp-update-config.lua
+++ b/openwisp-config/files/sbin/openwisp-update-config.lua
@@ -25,8 +25,7 @@ local check_dir = tmp_dir .. '/check'
 local check_config_dir = check_dir .. '/etc/config'
 local downloaded_conf = conf or (tmp_dir .. '/configuration.tar.gz')
 local openwisp_dir = not TEST and '/etc/openwisp' or working_dir .. '/openwisp'
-local standard_config_dir = not TEST and '/etc/config' or working_dir ..
-                              '/update-test/etc/config'
+local standard_config_dir = not TEST and '/etc/config' or working_dir .. '/update-test/etc/config'
 local test_root_dir = working_dir .. '/update-test'
 local remote_dir = openwisp_dir .. '/remote'
 local remote_config_dir = remote_dir .. '/etc/config'
@@ -34,7 +33,9 @@ local stored_dir = openwisp_dir .. '/stored'
 local stored_config_dir = stored_dir .. '/etc/config'
 local added_file = openwisp_dir .. '/added.list'
 local modified_file = openwisp_dir .. '/modified.list'
-local get_standard = function() return uci.cursor(standard_config_dir) end
+local get_standard = function()
+  return uci.cursor(standard_config_dir)
+end
 local get_remote = function()
   return uci.cursor(remote_config_dir, '/tmp/openwisp/.uci')
 end
@@ -119,17 +120,13 @@ if lfs.attributes(remote_config_dir, 'mode') == 'directory' then
           end
           -- remove entire section if empty
           local result = standard:get_all(file, section['.name'])
-          if result and utils.is_uci_empty(result) then
-            standard:delete(file, section['.name'])
-          end
+          if result and utils.is_uci_empty(result) then standard:delete(file, section['.name']) end
         end
       end
       standard:commit(file)
       -- remove uci file if empty
       local uci_file = standard:get_all(file)
-      if uci_file and utils.is_table_empty(uci_file) then
-        os.remove(standard_path)
-      end
+      if uci_file and utils.is_table_empty(uci_file) then os.remove(standard_path) end
     end
   end
 end
@@ -186,7 +183,9 @@ local modified_changed = false
 
 -- loop each file except directories and standard UCI config files
 local ignored_path = remote_config_dir .. '/'
-local function is_ignored(path) return utils.starts_with(path, ignored_path) end
+local function is_ignored(path)
+  return utils.starts_with(path, ignored_path)
+end
 
 for path, attr in utils.dirtree(remote_dir) do
   if attr.mode == 'file' and not is_ignored(path) then
@@ -223,8 +222,7 @@ for path, attr in utils.dirtree(remote_dir) do
       end
       -- add file to filesystem
       os.execute('mkdir -p ' .. utils.escape_shell_arg(dest_dir))
-      os.execute('cp ' .. utils.escape_shell_arg(path) .. ' ' ..
-                   utils.escape_shell_arg(dest_path))
+      os.execute('cp ' .. utils.escape_shell_arg(path) .. ' ' .. utils.escape_shell_arg(dest_path))
     end
   end
 end

--- a/openwisp-config/luaformat.config
+++ b/openwisp-config/luaformat.config
@@ -1,8 +1,11 @@
-column_limit: 86
+# LuaFormatter can emit a line one character over column_limit.
+# Use 109 to match Luacheck's 110-character maximum.
+column_limit: 109
 indent_width: 2
 tab_width: 2
 continuation_indent_width: 2
-column_table_limit: 86
+column_table_limit: 109
 line_breaks_after_function_body: 1
 align_args: false
 align_parameter: false
+keep_simple_function_one_line: false

--- a/openwisp-config/tests/test_net.lua
+++ b/openwisp-config/tests/test_net.lua
@@ -9,16 +9,18 @@ package.loaded['uci'] = {
   cursor = function()
     return {
       get = function(_, config, section, option)
-        if config ~= 'network' or not network_config[section] then
-          return nil
-        end
+        if config ~= 'network' or not network_config[section] then return nil end
         return network_config[section][option]
       end
     }
   end
 }
 
-package.loaded['nixio'] = {getifaddrs = function() return interfaces end}
+package.loaded['nixio'] = {
+  getifaddrs = function()
+    return interfaces
+  end
+}
 local net = require('openwisp.net')
 TestNet = {}
 

--- a/openwisp-config/tests/test_random_number.lua
+++ b/openwisp-config/tests/test_random_number.lua
@@ -1,15 +1,14 @@
 require('os')
 require('io')
 local luaunit = require('luaunit')
-local get_random_number = assert(
-  loadfile("../files/sbin/openwisp-get-random-number.lua"))
+local get_random_number = assert(loadfile("../files/sbin/openwisp-get-random-number.lua"))
 
 TestRandomDelay = {}
 
 function TestRandomDelay.test_default()
   -- testing casting error
-  luaunit.assertErrorMsgMatches(".*Could not cast 'delay' to number.*",
-    get_random_number, "--test=1", 0, "delay")
+  luaunit.assertErrorMsgMatches(".*Could not cast 'delay' to number.*", get_random_number, "--test=1", 0,
+    "delay")
   -- testing random value must be in range min to max
   local min = 0
   local max = 20

--- a/openwisp-config/tests/test_remove_default_wifi.lua
+++ b/openwisp-config/tests/test_remove_default_wifi.lua
@@ -1,12 +1,15 @@
 require('os')
 require('io')
 local luaunit = require('luaunit')
-local remove_default_wifi = assert(loadfile(
-  "../files/sbin/openwisp-remove-default-wifi.lua"))
+local remove_default_wifi = assert(loadfile("../files/sbin/openwisp-remove-default-wifi.lua"))
 
 TestRemoveDefaultWifi = {
-  setUp = function() os.execute('cp ./wifi/wireless ./config') end,
-  tearDown = function() os.execute('rm ./config/wireless') end
+  setUp = function()
+    os.execute('cp ./wifi/wireless ./config')
+  end,
+  tearDown = function()
+    os.execute('rm ./config/wireless')
+  end
 }
 
 function TestRemoveDefaultWifi.test_default()

--- a/openwisp-config/tests/test_restore_unmanaged.lua
+++ b/openwisp-config/tests/test_restore_unmanaged.lua
@@ -3,8 +3,7 @@ package.path = package.path .. ';../files/lib/?.lua'
 require('os')
 require('io')
 local luaunit = require('luaunit')
-local restore_unmanaged = assert(loadfile(
-  "../files/sbin/openwisp-restore-unmanaged.lua"))
+local restore_unmanaged = assert(loadfile("../files/sbin/openwisp-restore-unmanaged.lua"))
 local write_dir = './unmanaged/'
 
 TestRestoreUnmanaged = {

--- a/openwisp-config/tests/test_store_unmanaged.lua
+++ b/openwisp-config/tests/test_store_unmanaged.lua
@@ -4,9 +4,8 @@ require('os')
 require('io')
 local luaunit = require('luaunit')
 local store_unmanaged = assert(loadfile("../files/sbin/openwisp-store-unmanaged.lua"))
-local default_blocks = "system.ntp " .. "system.@led " .. "network.loopback " ..
-                         "network.@globals " .. "network.lan " .. "network.wan " ..
-                         "network.@switch " .. "network.@switch_vlan"
+local default_blocks = "system.ntp " .. "system.@led " .. "network.loopback " .. "network.@globals " ..
+                         "network.lan " .. "network.wan " .. "network.@switch " .. "network.@switch_vlan"
 local write_dir = './unmanaged/'
 local assertNotNil = luaunit.assertNotNil
 local assertNil = luaunit.assertNil

--- a/openwisp-config/tests/test_uci_autoname.lua
+++ b/openwisp-config/tests/test_uci_autoname.lua
@@ -30,13 +30,10 @@ function TestUciAutoname.test_default_behaviour()
   luaunit.assertNotNil(networkFile)
   local networkContents = networkFile:read('*all')
   luaunit.assertNotNil(string.find(networkContents, "config switch 'switch"))
-  luaunit.assertNotNil(string.find(networkContents,
-    "config switch_vlan 'switch0_vlan1"))
-  luaunit.assertNotNil(string.find(networkContents,
-    "config switch_port 'switch0_port1"))
+  luaunit.assertNotNil(string.find(networkContents, "config switch_vlan 'switch0_vlan1"))
+  luaunit.assertNotNil(string.find(networkContents, "config switch_port 'switch0_port1"))
   luaunit.assertNotNil(string.find(networkContents, "config globals 'globals"))
-  luaunit.assertNotNil(string.find(networkContents,
-    "config device 'device_lan2"))
+  luaunit.assertNotNil(string.find(networkContents, "config device 'device_lan2"))
   luaunit.assertNotNil(string.find(networkContents, "config route 'route1"))
   luaunit.assertNotNil(string.find(networkContents, "config route 'route2"))
   -- ensure rest of config options are present
@@ -49,10 +46,8 @@ function TestUciAutoname.test_default_behaviour()
   local wirelessFile = io.open(write_dir .. 'wireless')
   luaunit.assertNotNil(wirelessFile)
   local wirelessContents = wirelessFile:read('*all')
-  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan0",
-    nil, true))
-  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan1",
-    nil, true))
+  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan0", nil, true))
+  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-iface 'wifi_wlan1", nil, true))
   -- check system
   local systemFile = io.open(write_dir .. 'system')
   luaunit.assertNotNil(systemFile)

--- a/openwisp-config/tests/test_update_config.lua
+++ b/openwisp-config/tests/test_update_config.lua
@@ -15,145 +15,145 @@ local function string_count(base, pattern)
 end
 
 TestUpdateConfig = {
-    setUp = function()
-        os.execute('mkdir -p ' .. config_dir)
-        os.execute('mkdir -p ' .. remote_config_dir)
-        -- prepare config tar gz
-        os.execute('cp good-config.tar.gz configuration.tar.gz')
-        -- this file is preexisting on the device
-        os.execute('cp ./update/system '..config_dir..'system')
-        os.execute('cp ./update/network '..config_dir..'network')
-        os.execute('cp ./update/wireless '..config_dir..'wireless')
-        os.execute('cp ./update/firewall '..config_dir..'firewall')
-        -- we expect these UCI files to be removed
-        os.execute('cp ./config/wireless-autoname '..remote_config_dir..'/wireless-autoname')
-        os.execute('cp ./wifi/wireless '..remote_config_dir..'/wireless')
-        -- this file will be overwrited by stored configuration and new configuration
-        os.execute('cp ./wifi/wireless '..config_dir..'/wireless')
-        -- we expect this file to be stored
-        os.execute('echo original > '..write_dir..'/etc/existing')
-        -- we expect this regular file to be removed
-        os.execute('echo remove-me > '..write_dir..'/etc/remove-me')
-        os.execute('echo /etc/remove-me > '..openwisp_dir..'/added.list')
-        -- we expect this file to be restored
-        os.execute('mkdir -p ' .. openwisp_dir .. 'stored/etc/')
-        os.execute('echo restore-me > '..openwisp_dir..'/stored/etc/restore-me')
-        os.execute('echo /etc/restore-me > '..openwisp_dir..'/modified.list')
-        -- this file is stored in the backup
-        os.execute('mkdir -p ' .. stored_dir ..'etc/config/')
-        os.execute("cp ./update/stored_wireless " ..stored_dir.. '/etc/config/wireless')
-    end,
-    tearDown = function()
-        os.execute('rm -rf ' .. write_dir)
-        os.execute('rm -rf ' .. openwisp_dir)
-        os.execute('rm -rf invalid-conf')
-        os.execute('rm -f invalid-conf.tar.gz pwned')
-        os.execute('rm configuration.tar.gz')
-    end
+  setUp = function()
+    os.execute('mkdir -p ' .. config_dir)
+    os.execute('mkdir -p ' .. remote_config_dir)
+    -- prepare config tar gz
+    os.execute('cp good-config.tar.gz configuration.tar.gz')
+    -- this file is preexisting on the device
+    os.execute('cp ./update/system ' .. config_dir .. 'system')
+    os.execute('cp ./update/network ' .. config_dir .. 'network')
+    os.execute('cp ./update/wireless ' .. config_dir .. 'wireless')
+    os.execute('cp ./update/firewall ' .. config_dir .. 'firewall')
+    -- we expect these UCI files to be removed
+    os.execute('cp ./config/wireless-autoname ' .. remote_config_dir .. '/wireless-autoname')
+    os.execute('cp ./wifi/wireless ' .. remote_config_dir .. '/wireless')
+    -- this file will be overwrited by stored configuration and new configuration
+    os.execute('cp ./wifi/wireless ' .. config_dir .. '/wireless')
+    -- we expect this file to be stored
+    os.execute('echo original > ' .. write_dir .. '/etc/existing')
+    -- we expect this regular file to be removed
+    os.execute('echo remove-me > ' .. write_dir .. '/etc/remove-me')
+    os.execute('echo /etc/remove-me > ' .. openwisp_dir .. '/added.list')
+    -- we expect this file to be restored
+    os.execute('mkdir -p ' .. openwisp_dir .. 'stored/etc/')
+    os.execute('echo restore-me > ' .. openwisp_dir .. '/stored/etc/restore-me')
+    os.execute('echo /etc/restore-me > ' .. openwisp_dir .. '/modified.list')
+    -- this file is stored in the backup
+    os.execute('mkdir -p ' .. stored_dir .. 'etc/config/')
+    os.execute("cp ./update/stored_wireless " .. stored_dir .. '/etc/config/wireless')
+  end,
+  tearDown = function()
+    os.execute('rm -rf ' .. write_dir)
+    os.execute('rm -rf ' .. openwisp_dir)
+    os.execute('rm -rf invalid-conf')
+    os.execute('rm -f invalid-conf.tar.gz pwned')
+    os.execute('rm configuration.tar.gz')
+  end
 }
 
 function TestUpdateConfig.test_update()
-    update_config('--test=1')
-    -- check network
-    local networkFile = io.open(config_dir .. 'network')
-    luaunit.assertNotNil(networkFile)
-    local networkContents = networkFile:read('*all')
-    -- ensure interface added is present
-    luaunit.assertNotNil(string.find(networkContents, "config interface 'added'"))
-    luaunit.assertNotNil(string.find(networkContents, "option ifname 'added0'"))
-    -- ensure wg1 added via remote previously is present
-    luaunit.assertNotNil(string.find(networkContents, "config interface 'wg1'"))
-    luaunit.assertNotNil(string.find(networkContents, "option proto 'static'"))
-    -- ensure network file is stored for backup
-    local storedNetworkFile = io.open(stored_dir .. '/etc/config/network')
-    luaunit.assertNotNil(storedNetworkFile)
-    local storedNetworkContents = storedNetworkFile:read('*all')
-    -- ensure stored
-    luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wg1'"))
-    luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wan'"))
-    luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wg0'"))
-    -- ensure only options with differing values are stored
-    local storedFirewallFile = io.open(stored_dir .. '/etc/config/firewall')
-    luaunit.assertNotNil(storedFirewallFile)
-    local storedFirewallContents = storedFirewallFile:read('*all')
-    luaunit.assertNotNil(string.find(storedFirewallContents, "option forward 'REJECT'"))
-    luaunit.assertNotNil(string.find(storedFirewallContents, "option output 'ACCEPT'"))
-    -- check system
-    local systemFile = io.open(config_dir .. 'system')
-    luaunit.assertNotNil(systemFile)
-    local systemContents = systemFile:read('*all')
-    luaunit.assertNotNil(string.find(systemContents, "config system 'system'"))
-    luaunit.assertNotNil(string.find(systemContents, "option custom 'custom'"))
-    luaunit.assertNotNil(string.find(systemContents, "option hostname 'update_config'"))
-    luaunit.assertNotNil(string.find(systemContents, "config new 'new'"))
-    luaunit.assertNotNil(string.find(systemContents, "option test 'test'"))
-    -- ensure rest of config options are present
-    luaunit.assertNotNil(string.find(systemContents, "config timeserver 'ntp'"))
-    luaunit.assertNotNil(string.find(systemContents, "list server '3.openwrt.pool.ntp.org'"))
-    -- ensure system file is stored for backup
-    local storedSystemFile = io.open(stored_dir .. '/etc/config/network')
-    luaunit.assertNotNil(storedSystemFile)
-    local storedSystemContents = storedSystemFile:read('*all')
-    -- ensure hostname is not added that is updated from remote
-    luaunit.assertNil(string.find(storedSystemContents, "option hostname"))
-    -- ensure custom is not added that is downloaded from remote
-    luaunit.assertNil(string.find(storedSystemContents, "option custom 'custom'"))
-    -- ensure new is not added that is downloaded from remote
-    luaunit.assertNil(string.find(storedSystemContents, "config new 'new'"))
-    -- ensure test file is present
-    local testFile = io.open(write_dir .. 'etc/test')
-    luaunit.assertNotNil(testFile)
-    local testContents = testFile:read('*all')
-    luaunit.assertEquals(testContents, 'test\n')
-    -- ensure added.list is what we expect
-    local addedListFile = io.open(openwisp_dir .. '/added.list')
-    luaunit.assertNotNil(addedListFile)
-    -- ensure test file is present
-    local addedListContents = addedListFile:read('*all')
-    luaunit.assertEquals(addedListContents, '/etc/test\n')
-    -- ensure files are removed
-    luaunit.assertNil(io.open(config_dir..'/wireless-autoname'))
-    luaunit.assertNil(io.open(remote_config_dir..'/wireless-autoname'))
-    -- ensure file is not removed
-    luaunit.assertNotNil(io.open(remote_config_dir..'/wireless'))
-    -- ensure configuration is restored
-    local wirelessFile = io.open(config_dir..'/wireless')
-    luaunit.assertNotNil(wirelessFile)
-    local wirelessContents = wirelessFile:read('*all')
-    -- ensure device radio0 is stored from backup
-    luaunit.assertNotNil(string.find(wirelessContents, "config wifi-device 'radio0'", 1, true))
-    luaunit.assertNotNil(string.find(wirelessContents, "option path 'platform/ar934x_wmac'"))
-    luaunit.assertNotNil(string.find(wirelessContents, "option channel '9'"))
-    -- ensure device radio1 is removed as it is neither in backup nor in new configuration
-    luaunit.assertNil(string.find(wirelessContents, "config wifi-device 'radio1'"))
-    -- ensure device radio3 options are updated
-    luaunit.assertNotNil(string.find(wirelessContents, "config wifi-device 'radio3'", 1, true))
-    -- ensure channel is stored from backup
-    luaunit.assertNotNil(string.find(wirelessContents, "option channel '14'"))
-    -- ensure country value is used from new configuration
-    luaunit.assertNotNil(string.find(wirelessContents, "option country 'IT'"))
-    -- ensure hwmode is not stored as not available in remote config
-    luaunit.assertNil(string.find(wirelessContents, "option hwmode '11h'"))
-    -- ensure path has been removed
-    luaunit.assertNil(string.find(wirelessContents, "option path 'pci0000:00/0000:00:1c.2/0000:05:00.0'"))
-    -- ensure existing original file has been stored
-    local modifiedListFile = io.open(openwisp_dir .. '/modified.list')
-    luaunit.assertNotNil(modifiedListFile)
-    luaunit.assertEquals(modifiedListFile:read('*all'), '/etc/existing\n')
-    local storedExisitngFile = io.open(stored_dir .. '/etc/existing')
-    luaunit.assertNotNil(storedExisitngFile)
-    luaunit.assertEquals(storedExisitngFile:read('*all'), 'original\n')
-    -- ensure it has been modified
-    local existingFile = io.open(write_dir .. '/etc/existing')
-    luaunit.assertNotNil(existingFile)
-    luaunit.assertEquals(existingFile:read('*all'), 'modified\n')
-    -- ensure file is removed
-    luaunit.assertNil(io.open(write_dir .. '/etc/remove-me'))
-    -- ensure file is restored
-    local restoreFile = io.open(write_dir..'/etc/restore-me')
-    luaunit.assertNotNil(restoreFile)
-    luaunit.assertEquals(restoreFile:read('*all'), 'restore-me\n')
-    luaunit.assertNil(io.open(stored_dir .. '/etc/restore-me'))
+  update_config('--test=1')
+  -- check network
+  local networkFile = io.open(config_dir .. 'network')
+  luaunit.assertNotNil(networkFile)
+  local networkContents = networkFile:read('*all')
+  -- ensure interface added is present
+  luaunit.assertNotNil(string.find(networkContents, "config interface 'added'"))
+  luaunit.assertNotNil(string.find(networkContents, "option ifname 'added0'"))
+  -- ensure wg1 added via remote previously is present
+  luaunit.assertNotNil(string.find(networkContents, "config interface 'wg1'"))
+  luaunit.assertNotNil(string.find(networkContents, "option proto 'static'"))
+  -- ensure network file is stored for backup
+  local storedNetworkFile = io.open(stored_dir .. '/etc/config/network')
+  luaunit.assertNotNil(storedNetworkFile)
+  local storedNetworkContents = storedNetworkFile:read('*all')
+  -- ensure stored
+  luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wg1'"))
+  luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wan'"))
+  luaunit.assertNotNil(string.find(storedNetworkContents, "config interface 'wg0'"))
+  -- ensure only options with differing values are stored
+  local storedFirewallFile = io.open(stored_dir .. '/etc/config/firewall')
+  luaunit.assertNotNil(storedFirewallFile)
+  local storedFirewallContents = storedFirewallFile:read('*all')
+  luaunit.assertNotNil(string.find(storedFirewallContents, "option forward 'REJECT'"))
+  luaunit.assertNotNil(string.find(storedFirewallContents, "option output 'ACCEPT'"))
+  -- check system
+  local systemFile = io.open(config_dir .. 'system')
+  luaunit.assertNotNil(systemFile)
+  local systemContents = systemFile:read('*all')
+  luaunit.assertNotNil(string.find(systemContents, "config system 'system'"))
+  luaunit.assertNotNil(string.find(systemContents, "option custom 'custom'"))
+  luaunit.assertNotNil(string.find(systemContents, "option hostname 'update_config'"))
+  luaunit.assertNotNil(string.find(systemContents, "config new 'new'"))
+  luaunit.assertNotNil(string.find(systemContents, "option test 'test'"))
+  -- ensure rest of config options are present
+  luaunit.assertNotNil(string.find(systemContents, "config timeserver 'ntp'"))
+  luaunit.assertNotNil(string.find(systemContents, "list server '3.openwrt.pool.ntp.org'"))
+  -- ensure system file is stored for backup
+  local storedSystemFile = io.open(stored_dir .. '/etc/config/network')
+  luaunit.assertNotNil(storedSystemFile)
+  local storedSystemContents = storedSystemFile:read('*all')
+  -- ensure hostname is not added that is updated from remote
+  luaunit.assertNil(string.find(storedSystemContents, "option hostname"))
+  -- ensure custom is not added that is downloaded from remote
+  luaunit.assertNil(string.find(storedSystemContents, "option custom 'custom'"))
+  -- ensure new is not added that is downloaded from remote
+  luaunit.assertNil(string.find(storedSystemContents, "config new 'new'"))
+  -- ensure test file is present
+  local testFile = io.open(write_dir .. 'etc/test')
+  luaunit.assertNotNil(testFile)
+  local testContents = testFile:read('*all')
+  luaunit.assertEquals(testContents, 'test\n')
+  -- ensure added.list is what we expect
+  local addedListFile = io.open(openwisp_dir .. '/added.list')
+  luaunit.assertNotNil(addedListFile)
+  -- ensure test file is present
+  local addedListContents = addedListFile:read('*all')
+  luaunit.assertEquals(addedListContents, '/etc/test\n')
+  -- ensure files are removed
+  luaunit.assertNil(io.open(config_dir .. '/wireless-autoname'))
+  luaunit.assertNil(io.open(remote_config_dir .. '/wireless-autoname'))
+  -- ensure file is not removed
+  luaunit.assertNotNil(io.open(remote_config_dir .. '/wireless'))
+  -- ensure configuration is restored
+  local wirelessFile = io.open(config_dir .. '/wireless')
+  luaunit.assertNotNil(wirelessFile)
+  local wirelessContents = wirelessFile:read('*all')
+  -- ensure device radio0 is stored from backup
+  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-device 'radio0'", 1, true))
+  luaunit.assertNotNil(string.find(wirelessContents, "option path 'platform/ar934x_wmac'"))
+  luaunit.assertNotNil(string.find(wirelessContents, "option channel '9'"))
+  -- ensure device radio1 is removed as it is neither in backup nor in new configuration
+  luaunit.assertNil(string.find(wirelessContents, "config wifi-device 'radio1'"))
+  -- ensure device radio3 options are updated
+  luaunit.assertNotNil(string.find(wirelessContents, "config wifi-device 'radio3'", 1, true))
+  -- ensure channel is stored from backup
+  luaunit.assertNotNil(string.find(wirelessContents, "option channel '14'"))
+  -- ensure country value is used from new configuration
+  luaunit.assertNotNil(string.find(wirelessContents, "option country 'IT'"))
+  -- ensure hwmode is not stored as not available in remote config
+  luaunit.assertNil(string.find(wirelessContents, "option hwmode '11h'"))
+  -- ensure path has been removed
+  luaunit.assertNil(string.find(wirelessContents, "option path 'pci0000:00/0000:00:1c.2/0000:05:00.0'"))
+  -- ensure existing original file has been stored
+  local modifiedListFile = io.open(openwisp_dir .. '/modified.list')
+  luaunit.assertNotNil(modifiedListFile)
+  luaunit.assertEquals(modifiedListFile:read('*all'), '/etc/existing\n')
+  local storedExisitngFile = io.open(stored_dir .. '/etc/existing')
+  luaunit.assertNotNil(storedExisitngFile)
+  luaunit.assertEquals(storedExisitngFile:read('*all'), 'original\n')
+  -- ensure it has been modified
+  local existingFile = io.open(write_dir .. '/etc/existing')
+  luaunit.assertNotNil(existingFile)
+  luaunit.assertEquals(existingFile:read('*all'), 'modified\n')
+  -- ensure file is removed
+  luaunit.assertNil(io.open(write_dir .. '/etc/remove-me'))
+  -- ensure file is restored
+  local restoreFile = io.open(write_dir .. '/etc/restore-me')
+  luaunit.assertNotNil(restoreFile)
+  luaunit.assertEquals(restoreFile:read('*all'), 'restore-me\n')
+  luaunit.assertNil(io.open(stored_dir .. '/etc/restore-me'))
 end
 
 function TestUpdateConfig.test_update_conf_arg()
@@ -176,56 +176,56 @@ function TestUpdateConfig.test_update_conf_arg()
 end
 
 function TestUpdateConfig.test_duplicate_list_options()
-    update_config('--test=1', '--conf=./test-duplicate-list.tar.gz')
-    -- check network
-    local networkFile = io.open(config_dir .. 'network')
-    luaunit.assertNotNil(networkFile)
-    local networkContents = networkFile:read('*all')
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
-    luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
-    -- repeating the operation has the same result
-    update_config('--test=1', '--conf=./test-duplicate-list.tar.gz')
-    networkFile = io.open(config_dir .. 'network')
-    luaunit.assertNotNil(networkFile)
-    networkContents = networkFile:read('*all')
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
-    luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
+  update_config('--test=1', '--conf=./test-duplicate-list.tar.gz')
+  -- check network
+  local networkFile = io.open(config_dir .. 'network')
+  luaunit.assertNotNil(networkFile)
+  local networkContents = networkFile:read('*all')
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
+  luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
+  -- repeating the operation has the same result
+  update_config('--test=1', '--conf=./test-duplicate-list.tar.gz')
+  networkFile = io.open(config_dir .. 'network')
+  luaunit.assertNotNil(networkFile)
+  networkContents = networkFile:read('*all')
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
+  luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
 end
 
 function TestUpdateConfig.test_removal_list_options()
-    update_config('--test=1', '--conf=./test-list-removal.tar.gz')
-    -- -- check network
-    local networkFile = io.open(config_dir .. 'network')
-    luaunit.assertNotNil(networkFile)
-    local networkContents = networkFile:read('*all')
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 0)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 0)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
-    luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
-    luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
+  update_config('--test=1', '--conf=./test-list-removal.tar.gz')
+  -- -- check network
+  local networkFile = io.open(config_dir .. 'network')
+  luaunit.assertNotNil(networkFile)
+  local networkContents = networkFile:read('*all')
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.1/24'"), 0)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.2/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list ipaddr '192.168.10.3/24'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.2'"), 0)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.3'"), 1)
+  luaunit.assertEquals(string_count(networkContents, "list addresses '10.0.0.4'"), 2)
+  luaunit.assertNotNil(string.find(networkContents, "option test_restore '2'"))
 end
 
 function TestUpdateConfig.test_invalid_extra_file_path_is_skipped()
-    os.execute('mkdir -p invalid-conf')
-    os.execute('tar -zxf good-config.tar.gz -C invalid-conf')
-    -- Semicolons would be interpreted by the shell if this path was used raw.
-    os.execute('touch "invalid-conf/etc/x; touch pwned ;"')
-    os.execute('tar -czf invalid-conf.tar.gz -C invalid-conf etc')
-    update_config('--test=1', '--conf=./invalid-conf.tar.gz')
-    luaunit.assertNil(io.open('pwned'))
-    luaunit.assertNil(io.open(write_dir .. 'etc/x; touch pwned ;'))
+  os.execute('mkdir -p invalid-conf')
+  os.execute('tar -zxf good-config.tar.gz -C invalid-conf')
+  -- Semicolons would be interpreted by the shell if this path was used raw.
+  os.execute('touch "invalid-conf/etc/x; touch pwned ;"')
+  os.execute('tar -czf invalid-conf.tar.gz -C invalid-conf etc')
+  update_config('--test=1', '--conf=./invalid-conf.tar.gz')
+  luaunit.assertNil(io.open('pwned'))
+  luaunit.assertNil(io.open(write_dir .. 'etc/x; touch pwned ;'))
 end
 
 os.exit(luaunit.LuaUnit.run())

--- a/openwisp-config/tests/test_utils.lua
+++ b/openwisp-config/tests/test_utils.lua
@@ -12,7 +12,9 @@ TestUtils = {
     os.execute('mkdir ' .. write_dir)
     os.execute('touch ' .. write_dir .. '/network')
   end,
-  tearDown = function() os.execute('rm -rf ' .. write_dir) end
+  tearDown = function()
+    os.execute('rm -rf ' .. write_dir)
+  end
 }
 
 function TestUtils.test_starts_with_dot()
@@ -31,8 +33,7 @@ function TestUtils.test_is_valid_file_path()
 end
 
 function TestUtils.test_escape_shell_arg()
-  luaunit.assertEquals(utils.escape_shell_arg('/etc/config/network'),
-    "'/etc/config/network'")
+  luaunit.assertEquals(utils.escape_shell_arg('/etc/config/network'), "'/etc/config/network'")
   luaunit.assertEquals(utils.escape_shell_arg("a'b"), "'a'\\''b'")
 end
 
@@ -49,8 +50,7 @@ function TestUtils.test_write_uci_section_named()
   luaunit.assertNotNil(file)
   local contents = file:read('*all')
   luaunit.assertNotNil(string.find(contents, "config globals 'globals'"))
-  luaunit.assertNotNil(
-    string.find(contents, "option ula_prefix 'fd8e:f40a:fede::/48'"))
+  luaunit.assertNotNil(string.find(contents, "option ula_prefix 'fd8e:f40a:fede::/48'"))
 end
 
 function TestUtils.test_write_uci_section_anon()
@@ -327,8 +327,7 @@ end
 
 function TestUtils.test_starts_with()
   luaunit.assertEquals(utils.starts_with('/etc/config/network', '/etc/config/'), true)
-  luaunit.assertEquals(utils.starts_with('/etc/mypackage/myfile', '/etc/config/'),
-    false)
+  luaunit.assertEquals(utils.starts_with('/etc/mypackage/myfile', '/etc/config/'), false)
 end
 
 function TestUtils.test_sorted_pairs()
@@ -353,9 +352,9 @@ function TestUtils.test_write_uci_section_order()
   local file = io.open(write_dir .. '/network')
   luaunit.assertNotNil(file)
   local contents = file:read('*all')
-  local expected = "\toption aaaaaa 'should come first'\n" ..
-                     "\toption ula_prefix 'fd8e:f40a:fede::/48'\n" ..
-                     "\toption zzzzzz 'just a test'"
+  local expected =
+    "\toption aaaaaa 'should come first'\n" .. "\toption ula_prefix 'fd8e:f40a:fede::/48'\n" ..
+      "\toption zzzzzz 'just a test'"
   luaunit.assertNotNil(string.find(contents, expected))
 end
 

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -11,16 +11,24 @@ if [ "$CI" -eq 1 ]; then
 	cp openwisp-config/files/openwisp.init openwisp_init
 else
 	# check shell scripts formatting
-	sh_files=$(shfmt -f .)
+	sh_files=$(shfmt -f --apply-ignore .)
 	# shellcheck disable=SC2086
 	shellcheck $sh_files \
 		openwisp-config/files/openwisp.agent \
 		openwisp-config/files/openwisp.init
 
-	shfmt -d .
+	shfmt -d --apply-ignore .
 	shfmt -d openwisp-config/files/openwisp.agent
 	shfmt -d openwisp-config/files/openwisp.init
 fi
+
+(
+	cd openwisp-config
+	lua-format --check --config=luaformat.config \
+		files/sbin/*.lua \
+		files/lib/openwisp/*.lua \
+		tests/*.lua
+)
 
 openwisp-qa-check \
 	--skip-checkmigrations \


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request because they affect development tooling only.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code because the Lua changes are formatter output only.
- N/A I have updated the documentation because the existing developer documentation already describes LuaFormatter.

## Reference to Existing Issue

N/A

## Description of Changes

Aligns LuaFormatter output and Luacheck line lengths, adds non-mutating Lua formatting checks, makes local shell QA honor the generated build workspace ignore, and installs LuaFormatter for CI.

## Screenshot

N/A