### PR TITLE
[ci] Updated runbuild to OpenWrt 25.12 and APK artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
         id: cache
         uses: actions/cache@v6
         env:
-          cache-name: cache-openwisp-config-dependencies-openwrt-25.12
+          cache-name: cache-openwrt-dependencies
         with:
           path: "/home/runner/work/build"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('runbuild') }}
 
       - name: Set Environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           CI: 1
           CI_CACHE: ${{ steps.cache.outputs.cache-hit }}
+          OPENWRT_APK_PRIVATE_KEY: ${{ github.event_name == 'push' && secrets.OPENWRT_APK_PRIVATE_KEY || '' }}
 
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         id: cache
         uses: actions/cache@v6
         env:
-          cache-name: cache-openwisp-config-dependencies
+          cache-name: cache-openwisp-config-dependencies-openwrt-25.12
         with:
           path: "/home/runner/work/build"
           key: ${{ runner.os }}-build-${{ env.cache-name }}

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -53,6 +53,8 @@ its dependencies:
     make toolchain/install
     make package/openwisp-config/compile
 
+The compiled packages will go in ``bin/packages/*/openwisp``.
+
 Alternatively, you can configure your build interactively with ``make
 menuconfig``, in this case you will need to select *openwisp-config* by
 going to ``Administration > openwisp``:

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -44,9 +44,11 @@ its dependencies:
     cat feeds.conf.default >> feeds.conf
     ./scripts/feeds update -a
     ./scripts/feeds install -a
-    # any arch/target is fine because the package is architecture indipendent
-    arch="ar71xx"
-    echo "CONFIG_TARGET_$arch=y" > .config;
+    # any supported target and subtarget work because the package is architecture independent
+    target="ath79"
+    subtarget="generic"
+    echo "CONFIG_TARGET_$target=y" > .config
+    echo "CONFIG_TARGET_${target}_${subtarget}=y" >> .config
     echo "CONFIG_PACKAGE_openwisp-config=y" >> .config
     make defconfig
     make tools/install

--- a/docs/user/compiling.rst
+++ b/docs/user/compiling.rst
@@ -39,9 +39,11 @@ The following procedure illustrates how to compile a custom `OpenWrt
     cat feeds.conf.default >> feeds.conf
     ./scripts/feeds update -a
     ./scripts/feeds install -a
-    # replace with your desired arch target
-    arch="ar71xx"
-    echo "CONFIG_TARGET_$arch=y" > .config
+    # replace with your desired supported target and subtarget
+    target="ath79"
+    subtarget="generic"
+    echo "CONFIG_TARGET_$target=y" > .config
+    echo "CONFIG_TARGET_${target}_${subtarget}=y" >> .config
     echo "CONFIG_PACKAGE_openwisp-config=y" >> .config
     make defconfig
     # compile with verbose output

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -1,35 +1,42 @@
 Quick Start Guide
 =================
 
-To install the Config Agent on your OpenWrt system, follow these steps:
+Install the Config Agent on your OpenWrt system with:
 
-Download and install the latest build from `downloads.openwisp.io
-<http://downloads.openwisp.io/?prefix=openwisp-config/>`_. Copy the URL of
-the IPK file you want to download, then run the following commands on your
-OpenWrt device:
+.. code-block:: shell
 
-.. code-block:: bash
+    # OpenWrt >= 25.12
+    apk update
+    apk install openwisp-config
 
-    cd /tmp  # /tmp runs in memory
-    wget <URL-just-copied>
-    opkg update
-    opkg install ./<file-just-downloaded>
-
-Replace ``<URL-just-copied>`` with the URL of the package from
-`downloads.openwisp.io
-<http://downloads.openwisp.io/?prefix=openwisp-config/>`_.
-
-You can also install from the official OpenWrt packages:
-
-.. code-block:: bash
-
+    # OpenWrt <= 24.10
     opkg update
     opkg install openwisp-config
 
-.. important::
+Development Builds
+------------------
 
-    **We recommend installing from our latest builds** because the OpenWrt
-    packages are not always up to date.
+If you need an unreleased feature or bug fix, try the development version
+from `downloads.openwisp.io <https://downloads.openwisp.io/>`_. It
+provides APK packages built by our continuous integration. Before
+installing one, add the OpenWISP public key to the APK keyring:
+
+.. code-block:: shell
+
+    cat > /etc/apk/keys/openwisp-config.pem <<'EOF'
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYhhsie+759Mk34fJso4cDHVeLNeE
+    277qiiRySdHKYQNx8KV1RGd1ynm+5m+Z3RUl1BMYAAqi8Tip1+6q+DgEiQ==
+    -----END PUBLIC KEY-----
+    EOF
+
+Then download the ``openwisp-config`` APK from `the latest build
+<https://downloads.openwisp.io/?prefix=openwisp-config/latest/>`_ and
+install it. ``apk`` verifies its signature with the installed public key.
+
+.. code-block:: shell
+
+    apk add /tmp/openwisp-config_*.apk
 
 Once the config agent is installed, you need to configure it. Edit the
 config file located at ``/etc/config/openwisp``.

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -7,7 +7,7 @@ Install the Config Agent on your OpenWrt system with:
 
     # OpenWrt >= 25.12
     apk update
-    apk install openwisp-config
+    apk add openwisp-config
 
     # OpenWrt <= 24.10
     opkg update

--- a/runbuild
+++ b/runbuild
@@ -25,7 +25,7 @@ mkdir -p "$VERSIONED_DIR"
 cd "$BUILD_DIR"
 
 if ! [ -d "openwrt" ]; then
-	git clone https://git.openwrt.org/openwrt/openwrt.git --depth 1 --branch $OPENWRT_BRANCH
+	git clone https://git.openwrt.org/openwrt/openwrt.git
 fi
 cd openwrt
 git fetch origin

--- a/runbuild
+++ b/runbuild
@@ -25,12 +25,11 @@ mkdir -p "$VERSIONED_DIR"
 cd "$BUILD_DIR"
 
 if ! [ -d "openwrt" ]; then
-	git clone https://git.openwrt.org/openwrt/openwrt.git
+	git clone https://git.openwrt.org/openwrt/openwrt.git --depth 1 --branch $OPENWRT_BRANCH
 fi
 cd openwrt
-git fetch origin
-git checkout $OPENWRT_BRANCH
-git reset --hard origin/$OPENWRT_BRANCH
+git fetch --depth 1 origin $OPENWRT_BRANCH
+git checkout -B $OPENWRT_BRANCH FETCH_HEAD
 
 # OpenWrt generates a local key when CI does not provide the release key.
 trap 'rm -f private-key.pem' EXIT

--- a/runbuild
+++ b/runbuild
@@ -5,7 +5,6 @@
 # - $BUILD_DIR
 # - $DOWNLOADS_DIR
 # - $CORES (defaults to number of CPU cores on system)
-# - $COMPILE_TARGET (defaults to mips_24kc)
 set -e
 
 CI=${CI:-0}
@@ -16,11 +15,10 @@ BUILD_DIR=${BUILD_DIR-$(pwd)/build}
 DOWNLOADS_DIR=${DOWNLOADS_DIR-$(pwd)/downloads}
 START_TIME=${START_TIME-$(date +"%Y-%m-%d-%H%M%S")}
 VERSIONED_DIR="$DOWNLOADS_DIR/$START_TIME"
-COMPILE_TARGET=${COMPILE_TARGET-mips_24kc}
 LATEST_LINK="$DOWNLOADS_DIR/latest"
 CORES=${CORES:-$(nproc)}
 CURRENT_DIR=$(pwd)
-OPENWRT_BRANCH="openwrt-24.10"
+OPENWRT_BRANCH="openwrt-25.12"
 
 mkdir -p "$BUILD_DIR"
 mkdir -p "$VERSIONED_DIR"
@@ -30,9 +28,16 @@ if ! [ -d "openwrt" ]; then
 	git clone https://git.openwrt.org/openwrt/openwrt.git --depth 1 --branch $OPENWRT_BRANCH
 fi
 cd openwrt
-git reset --hard HEAD
+git fetch origin
 git checkout $OPENWRT_BRANCH
-git pull origin $OPENWRT_BRANCH
+git reset --hard origin/$OPENWRT_BRANCH
+
+# OpenWrt generates a local key when CI does not provide the release key.
+trap 'rm -f private-key.pem' EXIT
+if [ -n "${OPENWRT_APK_PRIVATE_KEY:-}" ]; then
+	printf '%s\n' "$OPENWRT_APK_PRIVATE_KEY" >private-key.pem
+	chmod 600 private-key.pem
+fi
 
 # configure feeds
 echo "src-link openwisp $CURRENT_DIR" >feeds.conf
@@ -42,31 +47,48 @@ sed -i '/telephony/d' feeds.conf
 sed -i '/routing/d' feeds.conf
 ./scripts/feeds update -a
 ./scripts/feeds install -a
-echo "CONFIG_PACKAGE_openwisp-config=y" >>.config
+{
+	echo "CONFIG_USE_APK=y"
+	echo "CONFIG_SIGNED_PACKAGES=y"
+	echo "CONFIG_PACKAGE_openwisp-config=y"
+} >>.config
 make defconfig
-
-# disable package signing: make defconfig sets CONFIG_SIGNED_PACKAGES=y by default
-# but usign is not available in CI, so we disable it to allow index generation
-sed -i 's/^CONFIG_SIGNED_PACKAGES=y$/CONFIG_SIGNED_PACKAGES=/' .config
+COMPILE_TARGET=$(grep -E '^CONFIG_TARGET_ARCH_PACKAGES="[^"]+"$' .config | cut -d '"' -f 2)
+if [ -z "$COMPILE_TARGET" ] || [ "$(printf '%s\n' "$COMPILE_TARGET" | wc -l)" -ne 1 ]; then
+	echo "ERROR: OpenWrt package architecture not found in .config"
+	exit 1
+fi
+PACKAGES_DIR="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp"
+rm -f "$PACKAGES_DIR"/*.apk "$PACKAGES_DIR"/packages.adb \
+	"$PACKAGES_DIR"/index.json "$PACKAGES_DIR"/public-key.pem
 
 if [ ! "$CI_CACHE" ]; then
 	make -j"$CORES" tools/install || make -j1 V=s tools/install
 	make -j"$CORES" toolchain/install || make -j1 V=s toolchain/install
 fi
 
-make -j"$CORES" package/openwisp-config/compile || make -j1 V=s package/openwisp-config/compile || exit 1
+make -j"$CORES" package/openwisp-config/compile \
+	|| make -j1 V=s package/openwisp-config/compile || exit 1
 
-# Publish sha256.manifest (renamed from Package.manifest) for integrity verification
+# package/index creates packages.adb, the APK repository index used by apk,
+# and index.json, a JSON representation of the package metadata.
 make package/index V=s
-PACKAGES_DIR="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp"
-MANIFEST_FILE="$PACKAGES_DIR/Packages.manifest"
-if [ ! -f "$MANIFEST_FILE" ]; then
-	echo "ERROR: Package manifest file not found at $MANIFEST_FILE"
+PUBLIC_KEY="$BUILD_DIR/openwrt/public-key.pem"
+if ! compgen -G "$PACKAGES_DIR/*.apk" >/dev/null; then
+	echo "ERROR: APK package files not found at $PACKAGES_DIR"
 	exit 1
 fi
-mv "$MANIFEST_FILE" "$PACKAGES_DIR/sha256.manifest"
-rm "$PACKAGES_DIR"/*.json
-rm "$PACKAGES_DIR"/Packages*
+if [ ! -f "$PUBLIC_KEY" ]; then
+	echo "ERROR: APK repository public key not found at $PUBLIC_KEY"
+	exit 1
+fi
+cp "$PUBLIC_KEY" "$PACKAGES_DIR"
+for index_file in packages.adb index.json public-key.pem; do
+	if [ ! -f "$PACKAGES_DIR/$index_file" ]; then
+		echo "ERROR: APK repository metadata not found at $PACKAGES_DIR/$index_file"
+		exit 1
+	fi
+done
 
 # Move artifacts
 mv "$PACKAGES_DIR" "$VERSIONED_DIR"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A. Manual device testing was not performed. Install the CI artifact on an OpenWrt 25.12 device using the updated quick-start instructions.
- N/A. Repository rules prohibit adding a shell test harness for this shell build change.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #276.

## Description of Changes

Updates `runbuild` for OpenWrt 25.12 and publishes its signed APK feed without removing required repository metadata. The feed retains APK files, `packages.adb`, `index.json`, and the public key. The workflow restores the protected APK signing key for release builds, while the user and developer documentation describe APK installation and the package output location.

## Screenshot

N/A.