### PR TITLE
[ci] Restored APK checksum manifest

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -30,12 +30,16 @@ Before installing one, add the OpenWISP public key to the APK keyring:
     -----END PUBLIC KEY-----
     EOF
 
-Then download the ``openwisp-config`` APK from `the latest build
-<https://downloads.openwisp.io/?prefix=openwisp-config/latest/>`_ and
-install it. ``apk`` verifies its signature with the installed public key.
+Then download the ``openwisp-config`` APK and ``sha256.manifest`` from
+`the latest build
+<https://downloads.openwisp.io/?prefix=openwisp-config/latest/>`_. Verify
+the APK checksum before installing it. ``apk`` verifies its signature with
+the installed public key.
 
 .. code-block:: shell
 
+    cd /tmp
+    sha256sum -c sha256.manifest
     apk add /tmp/openwisp-config_*.apk
 
 Once the config agent is installed, you need to configure it. Edit the

--- a/runbuild
+++ b/runbuild
@@ -59,7 +59,8 @@ if [ -z "$COMPILE_TARGET" ] || [ "$(printf '%s\n' "$COMPILE_TARGET" | wc -l)" -n
 fi
 PACKAGES_DIR="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp"
 rm -f "$PACKAGES_DIR"/*.apk "$PACKAGES_DIR"/packages.adb \
-	"$PACKAGES_DIR"/index.json "$PACKAGES_DIR"/public-key.pem
+	"$PACKAGES_DIR"/index.json "$PACKAGES_DIR"/public-key.pem \
+	"$PACKAGES_DIR"/sha256.manifest
 
 if [ ! "$CI_CACHE" ]; then
 	make -j"$CORES" tools/install || make -j1 V=s tools/install
@@ -77,12 +78,16 @@ if ! compgen -G "$PACKAGES_DIR/*.apk" >/dev/null; then
 	echo "ERROR: APK package files not found at $PACKAGES_DIR"
 	exit 1
 fi
+(
+	cd "$PACKAGES_DIR"
+	sha256sum ./*.apk >sha256.manifest
+)
 if [ ! -f "$PUBLIC_KEY" ]; then
 	echo "ERROR: APK repository public key not found at $PUBLIC_KEY"
 	exit 1
 fi
 cp "$PUBLIC_KEY" "$PACKAGES_DIR"
-for index_file in packages.adb index.json public-key.pem; do
+for index_file in packages.adb index.json public-key.pem sha256.manifest; do
 	if [ ! -f "$PACKAGES_DIR/$index_file" ]; then
 		echo "ERROR: APK repository metadata not found at $PACKAGES_DIR/$index_file"
 		exit 1


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A. This change has not been manually tested on an OpenWrt device.
- N/A. The build-script change has no existing shell test harness.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Restores `sha256.manifest` in the APK artifact directory. The manifest contains relative APK paths so users can verify downloaded development packages with `sha256sum -c sha256.manifest` before installation.

## Screenshot

N/A